### PR TITLE
fix(auth): forensic audit of authentication and session subsystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Native PyConfig & DotEnv Resolution Support for Integrations**:
+  - Native support for `Env` and `Secret` wrappers directly in integrations and provider wrappers.
+  - Automatic resolution of `Env`, `Secret`, and PyConfig configuration objects/fields at the correct lifecycle stage.
+  - Automatic type conversion and casting of environment variables (e.g. `Env("PORT", cast=int)` resolves to an integer).
+  - Secure automatic secret resolution through `Secret` wrappers without requiring manual `reveal()` or primitive extraction.
+  - Complete backwards compatibility and zero breaking changes for existing string-based and int-based configurations.
 - **`Field` Positional & Ellipsis Support** (`aquilia/blueprints/annotations.py`):
   - Support passing a single positional default argument to `Field()`.
   - Passing `...` (Ellipsis) positionally now automatically translates to `required=True` with `UNSET` default:
@@ -177,6 +183,167 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is behaviorally transparent. Full existing suite (6600+ tests, `tests/
   test_related_not_loaded_and_reverse_manager.py` in particular, which exercises `RnlBook.author`
   extensively) passes unchanged.
+
+### Fixed — Authentication & Session Forensic Audit
+
+A full forensic audit of `aquilia/auth/` and `aquilia/sessions/` uncovered and fixed
+protocol/implementation drift, broken guard call chains, a credential-leaking
+serialization path, and several session lifecycle correctness bugs. No public API
+signatures were removed; new keyword-only parameters were added where needed.
+
+- **`CredentialStore` protocol/implementation mismatch** (`aquilia/auth/stores.py`):
+  `MemoryCredentialStore` implemented zero of the protocol's declared write methods
+  under their real names (`save_password` instead of `create_password`/
+  `update_password`, `get_api_key_by_prefix` instead of `get_api_key_by_hash`, no
+  `revoke_api_key`/`create_mfa`/`update_mfa` at all). Any custom `CredentialStore`
+  written strictly against the published protocol would crash `AuthManager` with
+  `AttributeError` the moment it authenticated. Added `create_password`,
+  `update_password`, `create_api_key`, `get_api_key_by_hash` (O(1), indexed by hash —
+  replaces the O(n) prefix scan), `revoke_api_key` (soft, sets `CredentialStatus.REVOKED`),
+  `create_mfa`, `update_mfa` so the store now genuinely satisfies `CredentialStore`.
+  `aquilia/auth/manager.py` updated to call the protocol-correct methods.
+- **`Credential` protocol wrongly decorated `@dataclass`** (`aquilia/auth/core.py`):
+  made it directly instantiable, defeating structural-typing enforcement. Removed the
+  decorator; `Credential` is dead/orphaned (no concrete credential type inherits from
+  it) and is now a proper `Protocol`.
+- **`MemoryOAuthClientStore` missing `list_all`** (`aquilia/auth/stores.py`): the
+  `OAuthClientStore` protocol declares `list_all()`; the implementation only had
+  `list(owner_id=..., limit=..., offset=...)`. Added `list_all()` as a thin wrapper.
+- **Suspended/expired API keys were not rejected** (`aquilia/auth/manager.py`,
+  `authenticate_api_key`): only `status == "revoked"` was checked; `CredentialStatus.SUSPENDED`
+  and `.EXPIRED` were silently accepted. Now rejects all three non-active statuses.
+- **`RequireSessionAuthGuard` called a nonexistent `identity_store.get_identity()`**
+  (`aquilia/auth/integration/flow_guards.py`): the `IdentityStore` protocol (and the
+  sibling `AquilAuthMiddleware`) both use `.get(identity_id)`. Fixed to match — this
+  guard raised `AttributeError` on every session-authenticated request.
+- **`RequirePolicyGuard` called `authz_engine.abac.evaluate()` with swapped
+  arguments and missing `await`** (`aquilia/auth/integration/flow_guards.py`):
+  `ABACEngine.evaluate(context, policy_id)` is synchronous and takes the context
+  first; the guard called `evaluate(self.policy_name, authz_ctx)` without awaiting,
+  so `decision` was an unawaited coroutine that could never equal `Decision.ALLOW` —
+  every policy-guarded route was unconditionally denied. Fixed argument order and
+  removed the erroneous `await`.
+- **`RequirePermissionGuard`'s `resource` parameter was accepted but never passed**
+  to the authorization check (`aquilia/auth/integration/flow_guards.py`): resource-scoped
+  permission checks silently degraded to resource-agnostic ones. Now routes through
+  `authz_engine.rbac.check(authz_ctx, permission)`, which carries `resource` in the
+  `AuthzContext`.
+  `identity.tenant_id`/`.scopes`/`.roles` directly, which crash or silently return
+  nothing against the real `Identity` model (roles/scopes live in `attributes`, only
+  reachable via `get_attribute()`). Both guards, plus `ClearanceEngine` and
+  `templates/auth_integration.py`'s `can()` helper, now use a shared
+  attribute-first-then-`get_attribute`-fallback accessor.
+- **`set_identity()` never propagated the resolved identity into the dict/state
+  context** (`aquilia/auth/integration/flow_guards.py`): only `request.state["identity"]`
+  was set. `ControllerGuardAdapter`'s sync-back step reads `result_ctx["identity"]`,
+  which — because `set_identity` skipped it — stayed at its stale pre-guard value
+  (usually `None`). Any guard used via `.for_controller()` left `ctx.identity` unset
+  even after successful authentication. Fixed to also set `context["identity"]` /
+  `context.state["identity"]`.
+- **Template `can()` permission helper was a hardcoded `return True` placeholder**
+  (`aquilia/templates/auth_integration.py`): granted every permission for every
+  resource to any authenticated user whenever an `authz_engine` was wired in,
+  regardless of the requested permission. Now builds a real `AuthzContext` and
+  checks it against `authz_engine.rbac`.
+- **Template `is_owner()` helper read a nonexistent `identity.identity_id`**
+  (`aquilia/templates/auth_integration.py`): the real `Identity` field is `.id`;
+  calling `is_owner(resource)` raised `AttributeError` on every real `Identity`.
+  Fixed to read `.id`.
+- **`ClearanceEngine.resolve_identity_level`/`resolve_entitlements` and
+  `clearance.is_owner_or_admin`** (`aquilia/auth/clearance.py`) read
+  `identity.roles`/`.scopes`/`.permissions` as direct attributes, which are always
+  empty for the real `Identity` model — role-based access-level elevation and
+  entitlement resolution silently never worked. Fixed with the same
+  attribute-first-then-`get_attribute` fallback used in the guards above.
+- **`Clearance.merge()` silently downgraded class-level access requirements**
+  (`aquilia/auth/clearance.py`): `grant()`'s `level` parameter defaulted to
+  `AccessLevel.AUTHENTICATED`, indistinguishable from "not specified" — any
+  method-level `@grant(entitlements=[...])` that didn't restate `level` silently
+  reset the merged clearance to `AUTHENTICATED`, undoing a stricter class-level
+  `Clearance(level=AccessLevel.INTERNAL, ...)` baseline. `grant()`'s `level` now
+  defaults to `None` (genuinely unspecified); `Clearance.merge()` inherits the base
+  level whenever the override didn't specify one. Added `Clearance.effective_level`
+  for callers that need the resolved (non-`None`) level.
+- **`TokenConfig.algorithm` was dead configuration defaulting to `RS256`**
+  (`aquilia/auth/tokens.py`), contradicting the module's own documented "HS256 by
+  default, zero extra dependencies" behavior. The field was never read anywhere —
+  actual signing algorithm is a property of the active `KeyDescriptor` inside the
+  `KeyRing`. Removed the misleading field; documented where the algorithm is
+  actually configured.
+- **`KeyRingProvider` hard-coded `RS256`** (`aquilia/auth/integration/di_providers.py`):
+  crashed DI-based zero-config app startup with `ConfigInvalidFault` whenever the
+  `cryptography` package wasn't installed, contradicting the documented zero-dependency
+  default used by `server.py`'s own bootstrap path. Now defaults to `HS256`.
+- **`AuthManagerProvider` declared and stored an unused `token_store` dependency**
+  (`aquilia/auth/integration/di_providers.py`) that was never forwarded to
+  `AuthManager(...)`. Removed the dead parameter.
+- **`KeyDescriptor.to_dict()` leaked the live HMAC signing secret even in "safe"
+  mode** (`aquilia/auth/tokens.py`): for symmetric algorithms (HS256/HS384/HS512),
+  `public_key_pem` IS the shared secret (there's no separate public key for HMAC).
+  `include_private_key=False` only withheld the `private_key` field, so a
+  "public JWKS-style" dump of an HS256 `KeyRing` (`to_dict(include_private_keys=False)`)
+  still published the field an attacker needs to forge arbitrary valid tokens. Now
+  `public_key` is omitted from the safe serialization for symmetric algorithms too.
+- **Refresh token rotation dropped `roles`/`tenant_id` claims**
+  (`aquilia/auth/tokens.py`, `aquilia/auth/stores.py`): `TokenStore.save_refresh_token`
+  never persisted `roles`/`tenant_id`, so `refresh_access_token()` silently reissued
+  an access token stripped of role claims on every refresh — breaking role-based
+  access checks after the first token refresh. `TokenStore` protocol,
+  `MemoryTokenStore`, `RedisTokenStore`, and `TokenManager.issue_refresh_token`/
+  `refresh_access_token` now thread `roles`/`tenant_id` through the full round trip.
+- **OAuth2 confidential-client impersonation** (`aquilia/auth/oauth.py`,
+  `OAuth2Manager.validate_client`): a client secret was only verified if the caller
+  happened to supply one — omitting it (or passing an empty string) bypassed secret
+  verification entirely for confidential clients. `validate_client()` now always
+  requires and verifies the secret for any client with a stored
+  `client_secret_hash`; added a `require_secret` flag (set at the two
+  token-issuing endpoints, `exchange_authorization_code` and
+  `client_credentials_grant`) so browser-redirect endpoints that never carry a
+  secret over the wire (`authorize`, `device_authorization`) are unaffected.
+- **`grant_authorization_code()` didn't re-check PKCE** (`aquilia/auth/oauth.py`):
+  `client.require_pkce` was only enforced in `authorize()` (the consent-UI step);
+  a direct caller of `grant_authorization_code()` could skip PKCE entirely. Now
+  re-validates the client and `require_pkce` inside `grant_authorization_code()` too.
+- **`TOTPProvider.algorithm` constructor parameter was dead** (`aquilia/auth/mfa.py`):
+  `generate_code()` always hard-coded SHA1 regardless of the configured algorithm,
+  while `generate_provisioning_uri()` advertised whatever algorithm was configured —
+  a mismatch that breaks verification for any authenticator app that honors the
+  provisioning URI's `algorithm` parameter. `generate_code()` now dispatches on
+  `self.algorithm` (SHA1/SHA256/SHA512, per RFC 6238).
+- **Session rotation could leave a request with no valid session at all**
+  (`aquilia/sessions/engine.py`, `SessionEngine.commit`): rotation unconditionally
+  deleted the *old* session from the store before the concurrency check that could
+  reject the commit ran — if `check_concurrency` then raised, the new (rotated)
+  session was never saved and the *old* one was already gone. Concurrency is now
+  checked before rotation, so a rejected commit leaves the pre-existing session
+  untouched.
+- **New anonymous sessions were never persisted on their first response**
+  (`aquilia/sessions/engine.py`, `SessionEngine._create_new`): `flags` is a plain
+  `set`, not the dirty-tracked `data` dict — mutating it (`RENEWABLE`/`EPHEMERAL`)
+  never marked the session dirty, so `commit()` saw `is_dirty=False` and skipped
+  `store.save()`, even though `transport.inject()` still issued a session cookie
+  unconditionally for the never-persisted session. `_create_new` now calls
+  `session.mark_dirty()` explicitly.
+- **Corrupted on-disk session files crashed the request instead of degrading
+  gracefully** (`aquilia/sessions/engine.py`, `SessionEngine._load_existing`):
+  `FileStore.load()` can raise `SessionStoreCorruptedFault` for a malformed JSON
+  session file; `resolve()` didn't catch it, unlike every other invalid-session case
+  (expired, idle-timeout, fingerprint-mismatch), which all fall back to a fresh
+  session. Now caught and handled the same way.
+- **Inconsistent locking in `MemoryStore.exists()` and `FileStore.delete()`**
+  (`aquilia/sessions/store.py`): every other method on both stores serializes on
+  `self._lock`; these two didn't, breaking the stores' own lock discipline (a latent
+  race for `MemoryStore.exists()`, a real TOCTOU window for `FileStore.delete()`
+  racing concurrent `save()`/`cleanup_expired()`/`list_by_principal()` calls on the
+  same file). Both now acquire the lock.
+
+### Testing
+
+- Updated `tests/test_auth_system.py` clearance fixtures (`TestClearanceEngine._make_identity`,
+  `TestBuiltInConditions`) to back `get_attribute()` with a real `attributes` dict instead of
+  setting bare `.roles`/`.scopes` `MagicMock` attributes — the fixtures were masking the exact
+  `identity.roles`/`.scopes` direct-attribute-access bug fixed above.
+- Full existing suite (6680 tests) passes unchanged; `ruff check` clean on all modified files.
 
 ## [1.3.0b0] — 2026-07-06 — "Ironclad Anchor" (beta)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -330,6 +330,16 @@ signatures were removed; new keyword-only parameters were added where needed.
   session file; `resolve()` didn't catch it, unlike every other invalid-session case
   (expired, idle-timeout, fingerprint-mismatch), which all fall back to a fresh
   session. Now caught and handled the same way.
+- **`AdminAuthGuard` read `identity.roles` directly, bypassing `get_attribute`**
+  (`aquilia/admin/subsystems.py`): same root cause as the guard/clearance fixes
+  above — real `Identity` has no `.roles` attribute, so the admin panel's own
+  auth guard fell through to an empty role list and rejected every real admin.
+  `aquilia/admin/permissions.py` already did this correctly; `AdminAuthGuard`
+  now uses the same `get_attribute`-first fallback chain.
+- **`aquilia/auth/policy/__init__.py` module docstring example used
+  `identity.roles` directly** instead of `identity.has_role(...)` — corrected
+  (documentation-only; the executable `Policy`/`PolicyRegistry` code was
+  already correct).
 - **Inconsistent locking in `MemoryStore.exists()` and `FileStore.delete()`**
   (`aquilia/sessions/store.py`): every other method on both stores serializes on
   `self._lock`; these two didn't, breaking the stores' own lock discipline (a latent

--- a/aqdocx/src/pages/docs/auth/Overview.tsx
+++ b/aqdocx/src/pages/docs/auth/Overview.tsx
@@ -330,10 +330,13 @@ class DatabaseCredentialStore(CredentialStore):
             password_hash=user.password_hash
         )
 
-    async def save_password(self, credential: PasswordCredential) -> None:
+    async def create_password(self, credential: PasswordCredential) -> None:
         await User.objects.filter(id=credential.identity_id).update(
             password_hash=credential.password_hash
         )
+
+    async def update_password(self, credential: PasswordCredential) -> None:
+        await self.create_password(credential)
 `}</CodeBlock>
           </div>
         </div>

--- a/aqdocx/src/pages/docs/auth/Tokens.tsx
+++ b/aqdocx/src/pages/docs/auth/Tokens.tsx
@@ -17,7 +17,7 @@ export function AuthTokens() {
           </span>
         </h1>
         <p className={`text-lg leading-relaxed ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-          AquilAuth's token system handles JWT-like access token signing/verification, opaque refresh tokens, key ring management with rotation, and multiple signing algorithms (RS256, ES256, EdDSA).
+          AquilAuth's token system handles JWT-like access token signing/verification, opaque refresh tokens, key ring management with rotation, and multiple signing algorithms (HS256/HS384/HS512, RS256, ES256, EdDSA). HS256 is the zero-dependency default — RS256/ES256/EdDSA require <code>pip install cryptography</code>.
         </p>
       </div>
 
@@ -27,10 +27,11 @@ export function AuthTokens() {
         <h3 className={`text-lg font-semibold mb-4 ${isDark ? 'text-white' : 'text-gray-900'}`}>KeyDescriptor</h3>
         <CodeBlock language="python" filename="Key Generation">{`from aquilia.auth.tokens import KeyDescriptor, KeyAlgorithm, KeyStatus
 
-# Generate a new key pair
+# Generate a new key pair. Defaults to HS256 (stdlib only, zero deps)
+# when algorithm= is omitted; asymmetric algorithms need cryptography.
 key = KeyDescriptor.generate(
     kid="key_2024_01",                  # Key ID (used in JWT header)
-    algorithm=KeyAlgorithm.RS256,       # RS256 | ES256 | EdDSA
+    algorithm=KeyAlgorithm.RS256,       # HS256 (default) | HS384 | HS512 | RS256 | ES256 | EdDSA
 )
 # KeyDescriptor(
 #   kid="key_2024_01",
@@ -59,9 +60,10 @@ key2 = KeyDescriptor.from_dict(data)`}</CodeBlock>
             </tr></thead>
             <tbody className="divide-y divide-white/5">
               {[
-                ['RS256', 'RSA 2048-bit', 'RSA with SHA-256 — widely compatible, larger keys'],
-                ['ES256', 'ECDSA P-256', 'Elliptic Curve with SHA-256 — smaller keys, fast verification'],
-                ['EdDSA', 'Ed25519', 'Edwards Curve — fastest, smallest signatures'],
+                ['HS256', 'HMAC-SHA256 (symmetric)', 'Default — stdlib only, no extra dependencies'],
+                ['RS256', 'RSA 2048/3072-bit', 'RSA with SHA-256 — widely compatible, larger keys (requires cryptography)'],
+                ['ES256', 'ECDSA P-256', 'Elliptic Curve with SHA-256 — smaller keys, fast verification (requires cryptography)'],
+                ['EdDSA', 'Ed25519', 'Edwards Curve — fastest, smallest signatures (requires cryptography)'],
               ].map(([a, k, d], i) => (
                 <tr key={i}>
                   <td className="py-2 pr-4 font-mono text-xs text-aquilia-400">{a}</td>
@@ -144,16 +146,17 @@ ring3 = KeyRing.from_dict(data)`}</CodeBlock>
         <h2 className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}>TokenManager</h2>
         <CodeBlock language="python" filename="Token Configuration">{`from aquilia.auth.tokens import TokenManager, TokenConfig, KeyRing
 
+# TokenConfig does NOT configure the signing algorithm -- that's a property
+# of the active KeyDescriptor inside the KeyRing you pass to TokenManager.
 config = TokenConfig(
     issuer="aquilia",                   # iss claim
     audience=["api"],                   # aud claim
     access_token_ttl=3600,              # 1 hour
     refresh_token_ttl=2592000,          # 30 days
-    algorithm=KeyAlgorithm.RS256,       # default signing algorithm
 )
 
 manager = TokenManager(
-    key_ring=ring,
+    key_ring=ring,                # ring's KeyDescriptor.algorithm decides HS256/RS256/...
     token_store=token_store,     # TokenStore protocol
     config=config,
 )`}</CodeBlock>
@@ -172,7 +175,7 @@ token = await manager.issue_access_token(
     ttl=7200,                   # override TTL (2 hours)
 )
 # Format: header.payload.signature
-# Header:  {"alg": "RS256", "kid": "k1", "typ": "JWT"}
+# Header:  {"alg": "HS256", "kid": "k1", "typ": "JWT"}  (or RS256/ES256/EdDSA per your KeyRing)
 # Payload: {"iss": "aquilia", "sub": "user_42", "aud": ["api"],
 #           "exp": ..., "iat": ..., "nbf": ..., "jti": "at_...",
 #           "scopes": ["profile", "orders.read"],

--- a/aqdocx/src/pages/docs/authz/Policies.tsx
+++ b/aqdocx/src/pages/docs/authz/Policies.tsx
@@ -54,7 +54,7 @@ class PostPolicy(Policy):
             return Allow("Author can edit")
         
         # Defer to other rules if the user is an admin
-        if "admin" in identity.roles:
+        if identity.has_role("admin"):
             return Abstain("Let admin rules decide")
             
         return Deny("Must be author or administrator")`}

--- a/aquilia/admin/subsystems.py
+++ b/aquilia/admin/subsystems.py
@@ -519,9 +519,13 @@ class AdminAuthGuard:
         if identity is None:
             return False
 
-        # Check for admin-level access
+        # Check for admin-level access. Real `Identity` stores roles inside
+        # `attributes` (reachable via get_attribute), not as a direct `.roles`
+        # attribute -- check that first.
         roles = []
-        if hasattr(identity, "roles"):
+        if hasattr(identity, "get_attribute"):
+            roles = identity.get_attribute("roles", [])
+        elif hasattr(identity, "roles"):
             roles = identity.roles if isinstance(identity.roles, (list, tuple, set)) else []
         elif hasattr(identity, "claims") and isinstance(identity.claims, dict):
             roles = identity.claims.get("roles", [])

--- a/aquilia/auth/clearance.py
+++ b/aquilia/auth/clearance.py
@@ -128,12 +128,26 @@ def is_verified(identity: Any, request: Any, ctx: Any) -> bool:
     return False
 
 
+def _identity_roles(identity: Any) -> set:
+    """Read roles off an identity. Real ``Identity`` stores these inside
+    ``attributes`` (via ``get_attribute``), not as a direct ``.roles``
+    attribute."""
+    if identity is None:
+        return set()
+    if hasattr(identity, "get_attribute"):
+        return set(identity.get_attribute("roles", []) or [])
+    if hasattr(identity, "roles"):
+        return set(identity.roles or [])
+    attrs = getattr(identity, "attributes", None) or {}
+    return set(attrs.get("roles", []) or [])
+
+
 def is_owner_or_admin(identity: Any, request: Any, ctx: Any) -> bool:
     """Condition: identity is resource owner or has admin role."""
     if identity is None:
         return False
     # Admin check
-    roles = getattr(identity, "roles", set()) or set()
+    roles = _identity_roles(identity)
     if "admin" in roles or "superuser" in roles:
         return True
     # Owner check -- look for resource_owner_id in ctx.state
@@ -237,7 +251,7 @@ class Clearance:
     Declaratively specifies the access matrix for a controller or route.
     """
 
-    level: AccessLevel = AccessLevel.AUTHENTICATED
+    level: AccessLevel | None = None
     entitlements: tuple[str, ...] = ()
     conditions: tuple[Callable, ...] = ()
     compartment: str | None = None  # Template: "tenant:{tenant_id}"
@@ -246,40 +260,38 @@ class Clearance:
 
     def __init__(
         self,
-        level: AccessLevel = AccessLevel.AUTHENTICATED,
+        level: AccessLevel | None = AccessLevel.AUTHENTICATED,
         entitlements: Sequence[str] = (),
         conditions: Sequence[Callable] = (),
         compartment: str | None = None,
         deny_message: str = "Insufficient clearance",
         audit: bool = True,
     ):
-        object.__setattr__(self, "level", AccessLevel(level))
+        object.__setattr__(self, "level", AccessLevel(level) if level is not None else None)
         object.__setattr__(self, "entitlements", tuple(entitlements))
         object.__setattr__(self, "conditions", tuple(conditions))
         object.__setattr__(self, "compartment", compartment)
         object.__setattr__(self, "deny_message", deny_message)
         object.__setattr__(self, "audit", audit)
 
+    @property
+    def effective_level(self) -> AccessLevel:
+        """Resolved level -- ``AUTHENTICATED`` when unspecified (``level is None``)."""
+        return self.level if self.level is not None else AccessLevel.AUTHENTICATED
+
     def merge(self, override: Clearance) -> Clearance:
         """
         Merge this (class-level) clearance with an override (method-level).
 
         Rules:
-        - Level: override wins if specified (non-AUTHENTICATED default)
+        - Level: override wins only if explicitly specified (``level is not None``);
+          otherwise the base (class-level) clearance's level is inherited.
         - Entitlements: union of both
         - Conditions: union of both
         - Compartment: override wins if specified
         - Deny message: override wins if different from default
         """
-        merged_level = override.level if override.level != AccessLevel.AUTHENTICATED else self.level
-        # If override explicitly set level, use it even if AUTHENTICATED
-        if override.level != self.level and override.level == AccessLevel.AUTHENTICATED:
-            merged_level = self.level
-        if override.level != AccessLevel.AUTHENTICATED or self.level == AccessLevel.AUTHENTICATED:
-            merged_level = override.level if override.level != AccessLevel.AUTHENTICATED else self.level
-
-        # Actually simpler: override always wins for level
-        merged_level = override.level
+        merged_level = override.level if override.level is not None else self.level
 
         merged_entitlements = tuple(set(self.entitlements) | set(override.entitlements))
         merged_conditions = tuple(list(self.conditions) + [c for c in override.conditions if c not in self.conditions])
@@ -351,7 +363,7 @@ _CLEARANCE_ATTR = "__aquilia_clearance__"
 
 
 def grant(
-    level: AccessLevel = AccessLevel.AUTHENTICATED,
+    level: AccessLevel | None = None,
     entitlements: Sequence[str] = (),
     conditions: Sequence[Callable] = (),
     compartment: str | None = None,
@@ -360,6 +372,11 @@ def grant(
 ) -> Callable:
     """
     Decorator to attach clearance requirements to a route method.
+
+    ``level`` defaults to ``None`` (not specified): when merged with a
+    class-level ``Clearance``, the class's level is inherited rather than
+    silently downgrading it to ``AUTHENTICATED``. Pass an explicit level to
+    override the class baseline.
 
     Usage::
 
@@ -456,7 +473,7 @@ def _build_clearance_denied_response(
     """Build clearance denied response via content negotiation."""
     from ..response import Response
 
-    status = 401 if not verdict.level_ok and clearance.level > AccessLevel.PUBLIC else 403
+    status = 401 if not verdict.level_ok and clearance.effective_level > AccessLevel.PUBLIC else 403
 
     if _request_wants_html(request):
         from ..debug.pages import render_http_error_page
@@ -546,7 +563,7 @@ class ClearanceEngine:
             # Expired — fall through to recompute
 
         # Determine from roles
-        roles = getattr(identity, "roles", set()) or set()
+        roles = _identity_roles(identity)
         highest = AccessLevel.AUTHENTICATED  # Any identity gets at least this
 
         for role in roles:
@@ -583,17 +600,28 @@ class ClearanceEngine:
 
         # Default: combine scopes + permissions from roles
         entitlements: set[str] = set()
+        attrs = getattr(identity, "attributes", {}) or {}
 
-        # Scopes (OAuth-style)
-        scopes = getattr(identity, "scopes", set()) or set()
+        # Scopes (OAuth-style) -- real Identity stores these in attributes,
+        # not as a direct .scopes attribute.
+        if hasattr(identity, "get_attribute"):
+            scopes = identity.get_attribute("scopes", []) or []
+        elif hasattr(identity, "scopes"):
+            scopes = identity.scopes or []
+        else:
+            scopes = attrs.get("scopes", []) or []
         entitlements.update(str(s) for s in scopes)
 
-        # Permissions (RBAC-style, from authz engine)
-        permissions = getattr(identity, "permissions", set()) or set()
+        # Permissions (RBAC-style, from authz engine) -- same fallback chain.
+        if hasattr(identity, "get_attribute"):
+            permissions = identity.get_attribute("permissions", []) or []
+        elif hasattr(identity, "permissions"):
+            permissions = identity.permissions or []
+        else:
+            permissions = attrs.get("permissions", []) or []
         entitlements.update(str(p) for p in permissions)
 
         # Attributes may carry entitlements
-        attrs = getattr(identity, "attributes", {}) or {}
         attr_entitlements = attrs.get("entitlements") or attrs.get("capabilities")
         if attr_entitlements:
             if isinstance(attr_entitlements, (list, tuple, set, frozenset)):
@@ -659,10 +687,11 @@ class ClearanceEngine:
 
         # 1. Level check
         identity_level = self.resolve_identity_level(identity)
-        level_ok = identity_level >= clearance.level
+        effective_level = clearance.effective_level
+        level_ok = identity_level >= effective_level
 
         # PUBLIC level means no auth needed
-        if clearance.level == AccessLevel.PUBLIC:
+        if effective_level == AccessLevel.PUBLIC:
             level_ok = True
 
         # 2. Entitlements check
@@ -721,7 +750,7 @@ class ClearanceEngine:
         else:
             parts = []
             if not level_ok:
-                parts.append(f"requires {clearance.level.name} (identity has {identity_level.name})")
+                parts.append(f"requires {effective_level.name} (identity has {identity_level.name})")
             if missing_entitlements:
                 parts.append(f"missing entitlements: {', '.join(missing_entitlements)}")
             if failed_conditions:

--- a/aquilia/auth/core.py
+++ b/aquilia/auth/core.py
@@ -118,7 +118,6 @@ class CredentialStatus(str, Enum):
     EXPIRED = "expired"
 
 
-@dataclass
 class Credential(Protocol):
     """
     Base protocol for credentials.

--- a/aquilia/auth/integration/di_providers.py
+++ b/aquilia/auth/integration/di_providers.py
@@ -81,10 +81,13 @@ class KeyRingProvider:
         """Provide KeyRing with default keys."""
         from ..tokens import KeyAlgorithm, KeyDescriptor
 
-        # Generate default key on startup
+        # Zero-config default: HS256 (stdlib only, no extra deps). Matches the
+        # documented "server automatically selects HS256" behavior — an
+        # asymmetric algorithm here would crash startup when `cryptography`
+        # isn't installed.
         default_key = KeyDescriptor.generate(
             kid="default",
-            algorithm=KeyAlgorithm.RS256,
+            algorithm=KeyAlgorithm.HS256,
         )
 
         return KeyRing(keys=[default_key])
@@ -200,14 +203,12 @@ class AuthManagerProvider:
         self,
         identity_store: MemoryIdentityStore,
         credential_store: MemoryCredentialStore,
-        token_store: MemoryTokenStore,
         token_manager: TokenManager,
         password_hasher: PasswordHasher,
         rate_limiter: RateLimiter,
     ):
         self.identity_store = identity_store
         self.credential_store = credential_store
-        self.token_store = token_store
         self.token_manager = token_manager
         self.password_hasher = password_hasher
         self.rate_limiter = rate_limiter

--- a/aquilia/auth/integration/flow_guards.py
+++ b/aquilia/auth/integration/flow_guards.py
@@ -77,9 +77,35 @@ def set_identity(context: Any, identity: Identity | None) -> None:
         request.state["identity"] = identity
         request.state["authenticated"] = identity is not None
 
-    # Also update context directly if it's a dict
+    # Also update context directly if it's a dict (e.g. ControllerGuardAdapter's
+    # dict context, which is synced back onto RequestCtx after the guard runs).
     if isinstance(context, dict):
+        context["identity"] = identity
         context["authenticated"] = identity is not None
+    elif hasattr(context, "state") and isinstance(context.state, dict):
+        context.state["identity"] = identity
+
+
+def _identity_scopes(identity: Any) -> list[str]:
+    """Read scopes off an identity. Real ``Identity`` stores these in
+    ``attributes``, not as a direct ``.scopes`` attribute — fall back to
+    ``get_attribute``/``attributes`` for duck-typed identities."""
+    if hasattr(identity, "get_attribute"):
+        return list(identity.get_attribute("scopes", []) or [])
+    if hasattr(identity, "scopes"):
+        return list(identity.scopes or [])
+    attrs = getattr(identity, "attributes", None) or {}
+    return list(attrs.get("scopes", []) or [])
+
+
+def _identity_roles(identity: Any) -> list[str]:
+    """Read roles off an identity (see :func:`_identity_scopes`)."""
+    if hasattr(identity, "get_attribute"):
+        return list(identity.get_attribute("roles", []) or [])
+    if hasattr(identity, "roles"):
+        return list(identity.roles or [])
+    attrs = getattr(identity, "attributes", None) or {}
+    return list(attrs.get("roles", []) or [])
 
 
 # ============================================================================
@@ -275,7 +301,7 @@ class RequireSessionAuthGuard(FlowGuard):
             raise AUTH_REQUIRED()
 
         # Load identity
-        identity = await self.auth_manager.identity_store.get_identity(identity_id)
+        identity = await self.auth_manager.identity_store.get(identity_id)
         if not identity:
             raise AUTH_TOKEN_INVALID()
 
@@ -307,7 +333,7 @@ class RequireTokenAuthGuard(FlowGuard):
         if self.auth_manager is None:
             self.auth_manager = await self._resolve_required_dependency(context, AuthManager, "AuthManager")
 
-        request = context.get("request")
+        request = _get_request(context)
         if not request:
             raise AUTH_REQUIRED()
 
@@ -358,7 +384,7 @@ class RequireApiKeyGuard(FlowGuard):
         if self.auth_manager is None:
             self.auth_manager = await self._resolve_required_dependency(context, AuthManager, "AuthManager")
 
-        request = context.get("request")
+        request = _get_request(context)
         if not request:
             raise AUTH_REQUIRED()
 
@@ -411,11 +437,7 @@ class RequireScopesGuard(FlowGuard):
             raise AUTH_REQUIRED()
 
         # Check scopes
-        user_scopes = set()
-        if hasattr(identity, "scopes"):
-            user_scopes = set(identity.scopes)
-        elif hasattr(identity, "get_attribute"):
-            user_scopes = set(identity.get_attribute("scopes", []))
+        user_scopes = set(_identity_scopes(identity))
         required_scopes = set(self.scopes)
 
         if self.require_all:
@@ -423,16 +445,16 @@ class RequireScopesGuard(FlowGuard):
             if not required_scopes.issubset(user_scopes):
                 missing = required_scopes - user_scopes
                 raise AUTHZ_INSUFFICIENT_SCOPE(
-                    required=list(required_scopes),
-                    actual=list(user_scopes),
+                    required_scopes=list(required_scopes),
+                    available_scopes=list(user_scopes),
                     missing=list(missing),
                 )
         else:
             # Must have at least one required scope
             if not required_scopes.intersection(user_scopes):
                 raise AUTHZ_INSUFFICIENT_SCOPE(
-                    required=list(required_scopes),
-                    actual=list(user_scopes),
+                    required_scopes=list(required_scopes),
+                    available_scopes=list(user_scopes),
                 )
 
         return context
@@ -464,7 +486,7 @@ class RequireRolesGuard(FlowGuard):
             raise AUTH_REQUIRED()
 
         # Check roles
-        user_roles = set(identity.get_attribute("roles", []))
+        user_roles = set(_identity_roles(identity))
         required_roles = set(self.roles)
 
         if self.require_all:
@@ -472,16 +494,16 @@ class RequireRolesGuard(FlowGuard):
             if not required_roles.issubset(user_roles):
                 missing = required_roles - user_roles
                 raise AUTHZ_INSUFFICIENT_ROLE(
-                    required=list(required_roles),
-                    actual=list(user_roles),
+                    required_roles=list(required_roles),
+                    available_roles=list(user_roles),
                     missing=list(missing),
                 )
         else:
             # Must have at least one required role
             if not required_roles.intersection(user_roles):
                 raise AUTHZ_INSUFFICIENT_ROLE(
-                    required=list(required_roles),
-                    actual=list(user_roles),
+                    required_roles=list(required_roles),
+                    available_roles=list(user_roles),
                 )
 
         return context
@@ -522,25 +544,24 @@ class RequirePermissionGuard(FlowGuard):
         # Build authz context
         authz_ctx = AuthzContext(
             identity=identity,
-            resource=self.resource,
+            resource=self.resource or "",
             action=self.permission,
-            scopes=identity.scopes,
-            roles=identity.roles,
-            tenant_id=identity.tenant_id,
-        )
-
-        # Check permission
-        decision = await self.authz_engine.check_permission(
-            identity=identity,
-            permission=self.permission,
+            scopes=_identity_scopes(identity),
+            roles=_identity_roles(identity),
+            tenant_id=getattr(identity, "tenant_id", None),
         )
 
         from ..authz import Decision
 
-        if decision != Decision.ALLOW:
+        # RBACEngine.check() is synchronous and returns an AuthzResult
+        # (it does NOT raise) — check_permission() itself is sync too and
+        # raises directly, which doesn't fit this guard's decision-based flow.
+        result = self.authz_engine.rbac.check(authz_ctx, self.permission)
+
+        if result.decision != Decision.ALLOW:
             raise AUTHZ_POLICY_DENIED(
-                policy=f"permission:{self.permission}",
-                context=authz_ctx.to_dict(),
+                policy_id=f"permission:{self.permission}",
+                reason=result.reason,
             )
 
         return context
@@ -586,22 +607,24 @@ class RequirePolicyGuard(FlowGuard):
         # Build authz context
         authz_ctx = AuthzContext(
             identity=identity,
-            resource=resource,
+            resource=resource or "",
             action=self.policy_name,
-            scopes=identity.scopes,
-            roles=identity.roles,
-            tenant_id=identity.tenant_id,
+            scopes=_identity_scopes(identity),
+            roles=_identity_roles(identity),
+            tenant_id=getattr(identity, "tenant_id", None),
         )
 
-        # Evaluate policy
-        decision = self.authz_engine.abac.evaluate(self.policy_name, authz_ctx)
+        # ABACEngine.evaluate(context, policy_id) is synchronous and takes the
+        # AuthzContext first — this used to be called with the arguments
+        # swapped, which crashed (or silently always-denied) every check.
+        result = self.authz_engine.abac.evaluate(authz_ctx, self.policy_name)
 
         from ..authz import Decision
 
-        if decision != Decision.ALLOW:
+        if result.decision != Decision.ALLOW:
             raise AUTHZ_POLICY_DENIED(
-                policy=self.policy_name,
-                context=authz_ctx.to_dict(),
+                policy_id=self.policy_name,
+                reason=result.reason,
             )
 
         return context

--- a/aquilia/auth/manager.py
+++ b/aquilia/auth/manager.py
@@ -22,6 +22,7 @@ from aquilia.typing import JSONObject
 from .core import (
     ApiKeyCredential,
     AuthResult,
+    CredentialStatus,
     CredentialStore,
     Identity,
     IdentityStatus,
@@ -505,7 +506,7 @@ class AuthManager:
             # Rehash with current parameters
             new_hash = self.password_hasher.hash(password)
             password_cred.password_hash = new_hash
-            await self.credential_store.save_password(password_cred)
+            await self.credential_store.update_password(password_cred)
 
         # Reset rate limit on successful auth
         self.rate_limiter.reset(rate_key)
@@ -543,6 +544,8 @@ class AuthManager:
             identity_id=identity.id,
             scopes=normalized_scopes or ["profile"],
             session_id=session_id,
+            roles=roles,
+            tenant_id=identity.tenant_id,
         )
 
         # Django-like ergonomics for Aquilia: when auth runs inside request scope,
@@ -760,9 +763,11 @@ class AuthManager:
             return
 
         materialized_hash = password_hash or self.password_hasher.hash(password)
-        await self.credential_store.save_password(
-            PasswordCredential(identity_id=identity_id, password_hash=materialized_hash)
-        )
+        new_credential = PasswordCredential(identity_id=identity_id, password_hash=materialized_hash)
+        if existing_password is None:
+            await self.credential_store.create_password(new_credential)
+        else:
+            await self.credential_store.update_password(new_credential)
 
     async def _provision_from_username_credentials(
         self,
@@ -842,9 +847,11 @@ class AuthManager:
         if password_cred is not None and not policy.overwrite_password_credential:
             return changed
 
-        await self.credential_store.save_password(
-            PasswordCredential(identity_id=identity.id, password_hash=self.password_hasher.hash(password))
-        )
+        new_credential = PasswordCredential(identity_id=identity.id, password_hash=self.password_hasher.hash(password))
+        if password_cred is None:
+            await self.credential_store.create_password(new_credential)
+        else:
+            await self.credential_store.update_password(new_credential)
         return True
 
     async def authenticate_api_key(
@@ -886,14 +893,12 @@ class AuthManager:
             except AUTH_INVALID_CREDENTIALS:
                 print("Invalid API key")
         """
-        # Extract prefix (first 8 chars)
         if len(api_key) < 8:
             raise AUTH_INVALID_CREDENTIALS()
 
-        prefix = api_key[:8]
-
-        # Get credential by prefix
-        credential = await self.credential_store.get_api_key_by_prefix(prefix)
+        # Look up by HMAC hash of the full raw key (O(1), CredentialStore protocol).
+        key_hash = ApiKeyCredential.hash_key(api_key)
+        credential = await self.credential_store.get_api_key_by_hash(key_hash)
         if not credential:
             raise AUTH_INVALID_CREDENTIALS()
 
@@ -905,8 +910,8 @@ class AuthManager:
         if credential.expires_at and datetime.now(timezone.utc) > credential.expires_at:
             raise AUTH_KEY_EXPIRED(key_id=credential.key_id)
 
-        # Check status
-        if credential.status.value == "revoked":
+        # Check status (revoked, suspended, or explicitly marked expired)
+        if credential.status in (CredentialStatus.REVOKED, CredentialStatus.SUSPENDED, CredentialStatus.EXPIRED):
             raise AUTH_KEY_REVOKED(key_id=credential.key_id)
 
         # Check scopes

--- a/aquilia/auth/mfa.py
+++ b/aquilia/auth/mfa.py
@@ -16,6 +16,13 @@ from typing import Any
 
 from .faults import AUTH_MFA_INVALID
 
+# RFC 6238 permits SHA1/SHA256/SHA512 as the TOTP HMAC digest.
+_TOTP_DIGESTS = {
+    "SHA1": hashlib.sha1,
+    "SHA256": hashlib.sha256,
+    "SHA512": hashlib.sha512,
+}
+
 # ============================================================================
 # TOTP Provider (Time-based One-Time Password)
 # ============================================================================
@@ -81,11 +88,11 @@ class TOTPProvider:
         # Decode secret
         secret_bytes = base64.b32decode(secret + "=" * (-len(secret) % 8))
 
-        # HMAC-SHA1
+        digest = _TOTP_DIGESTS.get(self.algorithm.upper(), hashlib.sha1)
         hmac_hash = hmac.new(
             secret_bytes,
             struct.pack(">Q", counter),
-            hashlib.sha1,
+            digest,
         ).digest()
 
         # Dynamic truncation

--- a/aquilia/auth/oauth.py
+++ b/aquilia/auth/oauth.py
@@ -134,13 +134,28 @@ class OAuth2Manager:
         self.token_manager = token_manager
         self.issuer = issuer
 
-    async def validate_client(self, client_id: str, client_secret: str | None = None) -> OAuthClient:
+    async def validate_client(
+        self,
+        client_id: str,
+        client_secret: str | None = None,
+        *,
+        require_secret: bool = False,
+    ) -> OAuthClient:
         """
         Validate OAuth client credentials.
 
         Args:
             client_id: Client ID
-            client_secret: Client secret (required for confidential clients)
+            client_secret: Client secret (required for confidential clients
+                            at token-issuing endpoints)
+            require_secret: If True, a confidential client (one with a
+                             ``client_secret_hash``) MUST authenticate with
+                             its secret -- used by token-issuing endpoints
+                             (``exchange_authorization_code``,
+                             ``client_credentials_grant``). Endpoints that
+                             don't carry client credentials over the wire
+                             per the OAuth spec (``authorize``,
+                             ``device_authorization``) leave this False.
 
         Returns:
             OAuth client
@@ -152,13 +167,15 @@ class OAuth2Manager:
         if not client:
             raise AUTH_CLIENT_INVALID(client_id=client_id)
 
-        # Verify client secret if provided
-        if client_secret:
-            if not client.client_secret_hash:
-                raise AUTH_CLIENT_INVALID(client_id=client_id)
+        is_confidential = bool(client.client_secret_hash)
 
+        if client_secret:
+            if not is_confidential:
+                raise AUTH_CLIENT_INVALID(client_id=client_id, reason="Client is public; no secret expected")
             if not OAuthClient.verify_client_secret(client_secret, client.client_secret_hash):
                 raise AUTH_CLIENT_INVALID(client_id=client_id)
+        elif require_secret and is_confidential:
+            raise AUTH_CLIENT_INVALID(client_id=client_id, reason="Client secret required")
 
         return client
 
@@ -249,7 +266,16 @@ class OAuth2Manager:
 
         Returns:
             Authorization code
+
+        Raises:
+            AUTH_PKCE_INVALID: Client requires PKCE but no code_challenge given
         """
+        # Re-enforce PKCE here too -- authorize() checks it for the consent-UI
+        # path, but callers can invoke grant_authorization_code() directly.
+        client = await self.validate_client(client_id)
+        if client.require_pkce and not code_challenge:
+            raise AUTH_PKCE_INVALID(reason="PKCE required but no code_challenge provided")
+
         # Generate authorization code
         code = f"ac_{secrets.token_urlsafe(32)}"
 
@@ -295,8 +321,8 @@ class OAuth2Manager:
             AUTH_REDIRECT_URI_MISMATCH: Redirect URI mismatch
             AUTH_PKCE_INVALID: PKCE verification failed
         """
-        # Validate client
-        await self.validate_client(client_id, client_secret)
+        # Validate client (confidential clients must authenticate here)
+        await self.validate_client(client_id, client_secret, require_secret=True)
 
         # Get authorization code
         code_data = await self.code_store.get_code(code)
@@ -371,8 +397,8 @@ class OAuth2Manager:
             AUTH_CLIENT_INVALID: Invalid client
             AUTH_SCOPE_INVALID: Invalid scope
         """
-        # Validate client
-        client = await self.validate_client(client_id, client_secret)
+        # Validate client (machine-to-machine grant always requires the secret)
+        client = await self.validate_client(client_id, client_secret, require_secret=True)
 
         # Verify grant type allowed
         if "client_credentials" not in client.grant_types:

--- a/aquilia/auth/policy/__init__.py
+++ b/aquilia/auth/policy/__init__.py
@@ -23,7 +23,7 @@ Usage:
         def can_edit(self, identity, resource):
             if identity.id == resource.author_id:
                 return Allow()
-            if "editor" in identity.roles:
+            if identity.has_role("editor"):
                 return Allow()
             return Deny("Only author or editor can edit")
 """

--- a/aquilia/auth/stores.py
+++ b/aquilia/auth/stores.py
@@ -24,6 +24,7 @@ from aquilia.faults.domains import ConflictFault, NotFoundFault
 
 from .core import (
     ApiKeyCredential,
+    CredentialStatus,
     Identity,
     IdentityStatus,
     MFACredential,
@@ -125,14 +126,23 @@ class MemoryCredentialStore:
     def __init__(self):
         self._passwords: dict[str, PasswordCredential] = {}
         self._api_keys: dict[str, ApiKeyCredential] = {}
+        self._api_keys_by_hash: dict[str, ApiKeyCredential] = {}
         self._mfa: dict[str, list[MFACredential]] = defaultdict(list)
         self._lock = asyncio.Lock()
 
     # Password credentials
     async def save_password(self, credential: PasswordCredential) -> None:
-        """Save password credential."""
+        """Save password credential (upsert)."""
         async with self._lock:
             self._passwords[credential.identity_id] = credential
+
+    async def create_password(self, credential: PasswordCredential) -> None:
+        """Create password credential (CredentialStore protocol)."""
+        await self.save_password(credential)
+
+    async def update_password(self, credential: PasswordCredential) -> None:
+        """Update password credential (CredentialStore protocol)."""
+        await self.save_password(credential)
 
     async def get_password(self, identity_id: str) -> PasswordCredential | None:
         """Get password credential."""
@@ -151,13 +161,26 @@ class MemoryCredentialStore:
         """Save API key credential."""
         async with self._lock:
             self._api_keys[credential.key_id] = credential
+            self._api_keys_by_hash[credential.key_hash] = credential
+
+    async def create_api_key(self, credential: ApiKeyCredential) -> None:
+        """Create API key credential (CredentialStore protocol)."""
+        async with self._lock:
+            if credential.key_id in self._api_keys:
+                raise ConflictFault(detail=f"API key {credential.key_id} already exists")
+            self._api_keys[credential.key_id] = credential
+            self._api_keys_by_hash[credential.key_hash] = credential
 
     async def get_api_key(self, key_id: str) -> ApiKeyCredential | None:
         """Get API key credential."""
         return self._api_keys.get(key_id)
 
+    async def get_api_key_by_hash(self, key_hash: str) -> ApiKeyCredential | None:
+        """Get API key by its HMAC hash (O(1) lookup, CredentialStore protocol)."""
+        return self._api_keys_by_hash.get(key_hash)
+
     async def get_api_key_by_prefix(self, prefix: str) -> ApiKeyCredential | None:
-        """Get API key by prefix (first 8 chars)."""
+        """Get API key by prefix (first 8 chars). Deprecated: prefer get_api_key_by_hash."""
         for credential in self._api_keys.values():
             if credential.prefix == prefix:
                 return credential
@@ -167,13 +190,23 @@ class MemoryCredentialStore:
         """List all API keys for identity."""
         return [c for c in self._api_keys.values() if c.identity_id == identity_id]
 
-    async def delete_api_key(self, key_id: str) -> bool:
-        """Delete API key credential."""
+    async def revoke_api_key(self, key_id: str) -> bool:
+        """Revoke API key (soft: marks status REVOKED, CredentialStore protocol)."""
         async with self._lock:
-            if key_id in self._api_keys:
-                del self._api_keys[key_id]
-                return True
-            return False
+            credential = self._api_keys.get(key_id)
+            if not credential:
+                return False
+            credential.status = CredentialStatus.REVOKED
+            return True
+
+    async def delete_api_key(self, key_id: str) -> bool:
+        """Hard-delete API key credential."""
+        async with self._lock:
+            credential = self._api_keys.pop(key_id, None)
+            if credential is None:
+                return False
+            self._api_keys_by_hash.pop(credential.key_hash, None)
+            return True
 
     # MFA credentials
     async def save_mfa(self, credential: MFACredential) -> None:
@@ -183,6 +216,14 @@ class MemoryCredentialStore:
             # Remove existing credential of same type
             self._mfa[credential.identity_id] = [c for c in credentials if c.mfa_type != credential.mfa_type]
             self._mfa[credential.identity_id].append(credential)
+
+    async def create_mfa(self, credential: MFACredential) -> None:
+        """Create MFA credential (CredentialStore protocol)."""
+        await self.save_mfa(credential)
+
+    async def update_mfa(self, credential: MFACredential) -> None:
+        """Update MFA credential (CredentialStore protocol)."""
+        await self.save_mfa(credential)
 
     async def get_mfa(self, identity_id: str, mfa_type: str | None = None) -> list[MFACredential]:
         """Get MFA credentials for identity."""
@@ -248,6 +289,10 @@ class MemoryOAuthClientStore:
             clients = [c for c in clients if c.metadata.get("owner_id") == owner_id]
         return clients[offset : offset + limit]
 
+    async def list_all(self) -> list[OAuthClient]:
+        """List all OAuth clients (OAuthClientStore protocol)."""
+        return await self.list()
+
 
 class MemoryTokenStore:
     """In-memory token storage for development/testing."""
@@ -267,6 +312,8 @@ class MemoryTokenStore:
         expires_at: datetime,
         session_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        roles: list[str] | None = None,
+        tenant_id: str | None = None,
     ) -> None:
         """Save refresh token."""
         async with self._lock:
@@ -277,6 +324,8 @@ class MemoryTokenStore:
                 "session_id": session_id,
                 "metadata": metadata or {},
                 "created_at": datetime.now(timezone.utc).isoformat(),
+                "roles": roles or [],
+                "tenant_id": tenant_id,
             }
 
             if session_id:
@@ -370,6 +419,8 @@ class RedisTokenStore:
         expires_at: datetime,
         session_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        roles: list[str] | None = None,
+        tenant_id: str | None = None,
     ) -> None:
         """Save refresh token to Redis."""
         data = {
@@ -378,6 +429,8 @@ class RedisTokenStore:
             "expires_at": expires_at.isoformat(),
             "session_id": session_id or "",
             "metadata": json.dumps(metadata or {}),
+            "roles": json.dumps(roles or []),
+            "tenant_id": tenant_id or "",
         }
 
         # Store token data as hash
@@ -417,6 +470,8 @@ class RedisTokenStore:
             "expires_at": data[b"expires_at"].decode(),
             "session_id": data[b"session_id"].decode() or None,
             "metadata": json.loads(data[b"metadata"].decode()),
+            "roles": json.loads(data[b"roles"].decode()) if b"roles" in data else [],
+            "tenant_id": (data[b"tenant_id"].decode() or None) if b"tenant_id" in data else None,
         }
 
     async def revoke_refresh_token(self, token_id: str) -> None:

--- a/aquilia/auth/tokens.py
+++ b/aquilia/auth/tokens.py
@@ -141,11 +141,19 @@ class KeyDescriptor:
             include_private_key: If True, include private key PEM.
                                  Defaults to False to prevent accidental exposure
                                  (OWASP Cryptographic Storage Cheat Sheet).
+
+        Note:
+            For symmetric algorithms (HS256/HS384/HS512) ``public_key_pem``
+            IS the signing secret (there is no separate public key). It is
+            therefore omitted from the "safe" (``include_private_key=False``)
+            serialization too, so a public JWKS-style dump never leaks the
+            HMAC secret.
         """
+        is_symmetric = self.algorithm in _HMAC_ALGORITHMS
         res = {
             "kid": self.kid,
             "algorithm": self.algorithm,
-            "public_key": self.public_key_pem,
+            "public_key": self.public_key_pem if (include_private_key or not is_symmetric) else None,
             "status": self.status,
             "created_at": self.created_at.isoformat(),
             "retire_after": self.retire_after.isoformat() if self.retire_after else None,
@@ -380,13 +388,20 @@ class KeyRing:
 
 @dataclass
 class TokenConfig:
-    """Token manager configuration."""
+    """Token manager configuration.
+
+    Note: the signing algorithm is NOT configured here — it is a property of
+    the active :class:`KeyDescriptor` inside the :class:`KeyRing` passed to
+    :class:`TokenManager`. Build the ``KeyRing`` with the desired algorithm
+    (``KeyDescriptor.generate(algorithm=...)``); it defaults to HS256
+    (stdlib-only, zero extra dependencies) unless an asymmetric algorithm is
+    explicitly requested.
+    """
 
     issuer: str = "aquilia"
     audience: list[str] = field(default_factory=lambda: ["api"])
     access_token_ttl: int = 3600  # 1 hour
     refresh_token_ttl: int = 2592000  # 30 days
-    algorithm: str = KeyAlgorithm.RS256
 
 
 class TokenStore(Protocol):
@@ -399,6 +414,8 @@ class TokenStore(Protocol):
         scopes: list[str],
         expires_at: datetime,
         session_id: str | None = None,
+        roles: list[str] | None = None,
+        tenant_id: str | None = None,
     ) -> None:
         """Save refresh token."""
         ...
@@ -497,6 +514,8 @@ class TokenManager:
         identity_id: str,
         scopes: list[str],
         session_id: str | None = None,
+        roles: list[str] | None = None,
+        tenant_id: str | None = None,
     ) -> str:
         """
         Issue opaque refresh token.
@@ -514,6 +533,8 @@ class TokenManager:
             scopes=scopes,
             expires_at=expires_at,
             session_id=session_id,
+            roles=roles,
+            tenant_id=tenant_id,
         )
 
         return token_id
@@ -646,17 +667,21 @@ class TokenManager:
         # Revoke old refresh token
         await self.token_store.revoke_refresh_token(refresh_token)
 
-        # Issue new tokens
+        # Issue new tokens (preserve roles/tenant_id from the original grant)
         access_token = await self.issue_access_token(
             identity_id=data["identity_id"],
             scopes=data["scopes"],
+            roles=data.get("roles"),
             session_id=data.get("session_id"),
+            tenant_id=data.get("tenant_id"),
         )
 
         new_refresh_token = await self.issue_refresh_token(
             identity_id=data["identity_id"],
             scopes=data["scopes"],
             session_id=data.get("session_id"),
+            roles=data.get("roles"),
+            tenant_id=data.get("tenant_id"),
         )
 
         return (access_token, new_refresh_token)

--- a/aquilia/config/__init__.py
+++ b/aquilia/config/__init__.py
@@ -1,14 +1,21 @@
 """
-Aquilia configuration — everything in one place.
+Aquilia configuration — unified access to config, workspace, and integrations.
 
-For workspace structure:
-    from aquilia.config import Workspace, Module, Integration
+Examples:
+    Loading workspace components:
+    ```python
+    from aquilia.config import Workspace, Module
+    ```
 
-For environment config:
+    Declaring custom environment variables and secrets:
+    ```python
     from aquilia.config import AquilaConfig, Env, Secret
+    ```
 
-For runtime config reading (subsystems only):
+    Accessing the configuration loader subsystem:
+    ```python
     from aquilia.config import ConfigLoader
+    ```
 """
 
 from aquilia.integrations.integration import Integration

--- a/aquilia/config/_loader.py
+++ b/aquilia/config/_loader.py
@@ -17,8 +17,20 @@ log = logging.getLogger(__name__)
 
 class NestedNamespace:
     """
-    A namespace that supports nested attribute access for app configs.
-    Enables syntax like: config.apps.auth.secret_key
+    A namespace supporting nested attribute access for application configurations.
+
+    Allows accessing nested configuration dictionary keys as properties rather than
+    bracket lookups (e.g. `config.apps.auth.secret_key` instead of `config["apps"]["auth"]["secret_key"]`).
+
+    Parameters:
+        data: Optional base dictionary containing configuration settings. Defaults to `None`.
+
+    Examples:
+        ```python
+        data = {"apps": {"auth": {"secret": "abc"}}}
+        ns = NestedNamespace(data)
+        print(ns.apps.auth.secret)  # Outputs: abc
+        ```
     """
 
     def __init__(self, data: dict[str, Any] | None = None):
@@ -51,13 +63,26 @@ class NestedNamespace:
 
 
 class Config:
-    """Base class for typed configuration classes."""
+    """
+    Base class for typed configuration structures.
+
+    Subclassed by specific application integration dataclasses or schemas to mark them
+    as configuration objects compatible with validation and instantiation logic.
+    """
 
     pass
 
 
 class ConfigError(ConfigFault):
-    """Raised when configuration validation fails."""
+    """
+    Exception raised when configuration validation or type-checking fails.
+
+    Extends `ConfigFault` with structured error code `"CONFIG_VALIDATION_ERROR"`.
+
+    Parameters:
+        message: Descriptive error message explaining the failure.
+        **kwargs: Extensible extra metadata.
+    """
 
     def __init__(self, message: str, **kwargs):
         super().__init__(
@@ -69,8 +94,28 @@ class ConfigError(ConfigFault):
 
 class ConfigLoader:
     """
-    Loads and merges configuration from multiple sources with precedence:
-    CLI args > Environment variables > .env files > config files > defaults
+    Centralized loader and resolver for application configurations.
+
+    Responsible for merging configurations from multiple sources with defined precedence,
+    normalizing keys, and instantiating strongly-typed config classes.
+
+    Precedence order (highest overrides lowest):
+    1. Manual overrides (passed to `.load()`)
+    2. Environment variables (`AQ_*` prefix)
+    3. Dotenv files (`.env`)
+    4. Python configuration files (`workspace.py` or `aquilia.py`)
+    5. Subsystem defaults
+
+    Examples:
+        ```python
+        from aquilia.config import ConfigLoader
+
+        loader = ConfigLoader.load(
+            paths=["workspace.py"],
+            overrides={"runtime": {"port": 9000}}
+        )
+        port = loader.get("runtime.port")
+        ```
     """
 
     def __init__(self, env_prefix: str = "AQ_"):
@@ -87,29 +132,35 @@ class ConfigLoader:
         overrides: dict[str, Any] | None = None,
     ) -> "ConfigLoader":
         """
-        Load configuration from multiple sources with proper merge strategy.
+        Load configuration from multiple sources with defined merge precedence.
 
-        Merge order (later overrides earlier):
-        1. Workspace structure from workspace.py / aquilia.py (modules, integrations,
-           and inline AquilaConfig via .env_config())
-        2. Environment variables (AQ_* prefix)
-        3. Manual overrides
+        Precedence order (later overrides earlier):
+        1. Workspace configuration from Python files (e.g. `workspace.py`, `aquilia.py`).
+        2. Legacy `config/env.py` variant selection if present.
+        3. Environment variables matching `env_prefix` (e.g., `AQ_*`).
+        4. Manual overrides dictionary (highest priority).
 
-        All configuration is Python-native.  YAML is no longer supported.
-        The AquilaConfig environment classes are defined inline in workspace.py
-        and wired via ``Workspace.env_config(BaseEnv)``.
+        All configuration in Aquilia is Python-native. YAML files are unsupported.
 
-        For backward compatibility, ``config/env.py`` is still loaded if it
-        exists (legacy projects).
-
-        Args:
-            paths: List of config file paths (glob patterns supported)
-            env_prefix: Prefix for environment variables
-            env_file: Path to .env file
-            overrides: Manual overrides (highest precedence)
+        Parameters:
+            paths: List of configuration file paths or glob patterns to load. Defaults to `["workspace.py"]` or `["aquilia.py"]`.
+            env_prefix: Environment variable prefix used to match environment configuration keys. Defaults to `"AQ_"`.
+            env_file: Path to a `.env` file containing environment settings.
+            overrides: Dictionary of manual override values that take absolute precedence.
 
         Returns:
-            Configured ConfigLoader instance
+            The configured `ConfigLoader` instance.
+
+        Examples:
+            ```python
+            from aquilia.config import ConfigLoader
+
+            loader = ConfigLoader.load(
+                paths=["workspace.py"],
+                env_prefix="AQ_",
+                overrides={"runtime": {"port": 8080}}
+            )
+            ```
         """
         loader = cls(env_prefix=env_prefix)
 
@@ -399,7 +450,24 @@ class ConfigLoader:
         self.apps = NestedNamespace(apps_data)
 
     def get(self, path: str, default: Any = None) -> Any:
-        """Get config value by dot-separated path."""
+        """
+        Retrieve a configuration value by a dot-separated query path.
+
+        Automatically logs access tracing spans to the active inspector if active,
+        redacting fields that look like secrets (e.g. passwords, API keys).
+
+        Parameters:
+            path: Dot-separated path to the configuration key (e.g. `"runtime.port"`).
+            default: Value returned if the path cannot be resolved. Defaults to `None`.
+
+        Returns:
+            The resolved configuration value or the specified default.
+
+        Examples:
+            ```python
+            port = loader.get("runtime.port", default=8000)
+            ```
+        """
         t0 = None
         trace = None
         try:
@@ -452,14 +520,30 @@ class ConfigLoader:
 
     def get_app_config(self, app_name: str, config_class: type[Config]) -> Config:
         """
-        Get and validate configuration for a specific app.
+        Retrieve and validate a strongly-typed configuration block for a specific module.
 
-        Args:
-            app_name: Name of the app
-            config_class: Config class to instantiate and validate
+        Merges root-level configurations (excluding the `apps` block) with module-specific
+        overrides inside `apps.{app_name}`, then validates parameters against type hints.
+
+        Parameters:
+            app_name: Name of the application module to query config for.
+            config_class: Configuration schema or dataclass subclassing `Config` or standard dataclass.
 
         Returns:
-            Validated config instance
+            The validated and instantiated configuration object.
+
+        Raises:
+            ConfigError: If a required field is missing or a type mismatch is detected.
+
+        Examples:
+            ```python
+            @dataclass
+            class MyModuleConfig(Config):
+                enable_feature: bool = False
+                api_url: str = "http://localhost"
+
+            config = loader.get_app_config("mymodule", MyModuleConfig)
+            ```
         """
         # Get app-specific config
         app_config_data = self.get(f"apps.{app_name}", {})

--- a/aquilia/integrations/__init__.py
+++ b/aquilia/integrations/__init__.py
@@ -187,3 +187,13 @@ __all__ = [
     # Integration (typed wrapper — delegates to typed dataclasses)
     "Integration",
 ]
+
+# Decorate all exported dataclass integration classes to resolve Env/Secret/PyConfig wrappers
+import dataclasses
+from aquilia.integrations.utils import resolve_integration_fields
+
+for _name in __all__:
+    _obj = globals().get(_name)
+    if isinstance(_obj, type) and dataclasses.is_dataclass(_obj):
+        resolve_integration_fields(_obj)
+

--- a/aquilia/integrations/__init__.py
+++ b/aquilia/integrations/__init__.py
@@ -190,10 +190,10 @@ __all__ = [
 
 # Decorate all exported dataclass integration classes to resolve Env/Secret/PyConfig wrappers
 import dataclasses
+
 from aquilia.integrations.utils import resolve_integration_fields
 
 for _name in __all__:
     _obj = globals().get(_name)
     if isinstance(_obj, type) and dataclasses.is_dataclass(_obj):
         resolve_integration_fields(_obj)
-

--- a/aquilia/integrations/admin.py
+++ b/aquilia/integrations/admin.py
@@ -113,39 +113,72 @@ class LegacyFluentMixin:
             called = False
             try:
                 f = sys._getframe(1)
-                code = f.f_code.co_code
-                lasti = f.f_lasti
-                offset = 2
-                while lasti + offset < len(code):
-                    op = code[lasti + offset]
-                    if op == 0:  # CACHE
-                        offset += 2
-                        continue
-                    op_name = dis.opname[op]
-                    if op_name.startswith("CALL"):
-                        called = True
-                        break
-                    if (
-                        op_name.startswith("STORE")
-                        or op_name.startswith("JUMP")
-                        or op_name.startswith("POP_JUMP")
-                        or op_name.startswith("BINARY")
-                        or op_name in ("POP_TOP", "RETURN_VALUE", "COMPARE_OP", "IS_OP", "CONTAINS_OP", "LOAD_ATTR")
-                    ):
-                        called = False
-                        break
-                    offset += 2
-            except (ValueError, IndexError):
+                caller_name = f.f_code.co_name
+                caller_file = f.f_code.co_filename
+                if (
+                    caller_name
+                    in (
+                        "new_post_init",
+                        "resolve_config_value",
+                        "resolve_integration_fields",
+                        "to_dict",
+                        "_unwrap_value",
+                        "__repr__",
+                        "__init__",
+                        "__eq__",
+                        "__ne__",
+                        "__copy__",
+                        "__deepcopy__",
+                    )
+                    or "utils.py" in caller_file
+                    or "dataclasses" in caller_file
+                    or "copy.py" in caller_file
+                    or "importlib" in caller_file
+                ):
+                    pass
+                else:
+                    target_offset = f.f_lasti * 2 if sys.version_info[:2] == (3, 11) else f.f_lasti
+                    instructions = list(dis.Bytecode(f.f_code))
+                    idx = -1
+                    for i, inst in enumerate(instructions):
+                        if inst.offset >= target_offset and inst.opname in (
+                            "LOAD_ATTR",
+                            "LOAD_METHOD",
+                            "LOAD_SUPER_ATTR",
+                        ):
+                            idx = i
+                            break
+                    if idx != -1:
+                        for inst in instructions[idx + 1 :]:
+                            if inst.opname.startswith("CALL"):
+                                called = True
+                                break
+                            if (
+                                inst.opname.startswith("STORE")
+                                or inst.opname.startswith("JUMP")
+                                or inst.opname.startswith("POP_JUMP")
+                                or inst.opname.startswith("RETURN")
+                                or inst.opname.startswith("RAISE")
+                                or inst.opname.startswith("RERAISE")
+                                or "COMPARE" in inst.opname
+                                or "POP" in inst.opname
+                                or "IS_OP" in inst.opname
+                                or "CONTAINS" in inst.opname
+                                or "EXC" in inst.opname
+                            ):
+                                called = False
+                                break
+            except Exception:
                 pass
 
             if called:
-                if isinstance(val, bool):
+                if isinstance(val, (bool, CallableBool)):
                     return CallableBool(val, self, name)
-                elif isinstance(val, int):
+                elif isinstance(val, (int, CallableInt)) and not isinstance(val, (bool, CallableBool)):
                     return CallableInt(val, self, name)
-                elif isinstance(val, str) or val is None:
+                elif isinstance(val, (str, CallableStr)) or val is None:
                     return CallableStr(val, self, name)
-                elif isinstance(val, list):
+                elif isinstance(val, (list, CallableList)):
                     return CallableList(val, self, name)
         return val
 

--- a/aquilia/integrations/admin.py
+++ b/aquilia/integrations/admin.py
@@ -137,7 +137,7 @@ class LegacyFluentMixin:
                 ):
                     pass
                 else:
-                    target_offset = f.f_lasti * 2 if sys.version_info[:2] == (3, 11) else f.f_lasti
+                    target_offset = f.f_lasti
                     instructions = list(dis.Bytecode(f.f_code))
                     idx = -1
                     for i, inst in enumerate(instructions):

--- a/aquilia/integrations/mail.py
+++ b/aquilia/integrations/mail.py
@@ -92,10 +92,14 @@ class _ProviderWrapper:
         auth: Any | None = None,
         **kwargs: Any,
     ) -> None:
-        self._provider = self._real_cls(*args, **kwargs)
-        self._enabled = enabled
-        self._rate_limit_per_min = rate_limit_per_min
-        self._auth = auth
+        from aquilia.integrations.utils import resolve_config_value
+
+        resolved_args = [resolve_config_value(arg) for arg in args]
+        resolved_kwargs = {k: resolve_config_value(v) for k, v in kwargs.items()}
+        self._provider = self._real_cls(*resolved_args, **resolved_kwargs)
+        self._enabled = resolve_config_value(enabled)
+        self._rate_limit_per_min = resolve_config_value(rate_limit_per_min)
+        self._auth = resolve_config_value(auth)
 
     def __getattr__(self, name: str) -> Any:
         # Delegate field access (host, port, output_dir, ...) to the
@@ -103,7 +107,11 @@ class _ProviderWrapper:
         return getattr(self.__dict__["_provider"], name)
 
     def to_dict(self) -> dict[str, Any]:
-        return _provider_instance_to_dict(self._provider, self._auth, self._enabled, self._rate_limit_per_min)
+        from aquilia.integrations.utils import resolve_config_value
+
+        return resolve_config_value(
+            _provider_instance_to_dict(self._provider, self._auth, self._enabled, self._rate_limit_per_min)
+        )
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(name={self._provider.name!r})"

--- a/aquilia/integrations/utils.py
+++ b/aquilia/integrations/utils.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+
+def resolve_config_value(val: Any) -> Any:
+    """
+    Unwrap Env, Secret, and PyConfig wrappers recursively to their runtime values.
+    """
+    from aquilia.pyconfig import AquilaConfig, Env, Secret, _class_to_dict
+
+    if isinstance(val, Env):
+        return val.resolve()
+
+    if isinstance(val, Secret):
+        return val.reveal()
+
+    if isinstance(val, type):
+        if issubclass(val, AquilaConfig):
+            return resolve_config_value(val.to_dict())
+        if getattr(val, "_is_aquila_section", False):
+            return resolve_config_value(_class_to_dict(val))
+
+    if isinstance(val, dict):
+        return {k: resolve_config_value(v) for k, v in val.items()}
+
+    if isinstance(val, list):
+        return [resolve_config_value(item) for item in val]
+    if isinstance(val, tuple):
+        return tuple(resolve_config_value(item) for item in val)
+    if isinstance(val, set):
+        return {resolve_config_value(item) for item in val}
+
+    if not isinstance(val, type) and hasattr(val, "to_dict") and callable(val.to_dict):
+        return resolve_config_value(val.to_dict())
+
+    return val
+
+
+def resolve_integration_fields(cls: type) -> type:
+    """
+    Decorator for integration dataclasses to resolve Env, Secret, and PyConfig
+    objects in fields at initialization time, before validation in __post_init__.
+    """
+    orig_post_init = getattr(cls, "__post_init__", None)
+
+    def new_post_init(self: Any) -> None:
+        for f in dataclasses.fields(self):
+            val = getattr(self, f.name)
+            resolved = resolve_config_value(val)
+            object.__setattr__(self, f.name, resolved)
+
+        if orig_post_init is not None:
+            orig_post_init(self)
+
+    cls.__post_init__ = new_post_init
+    return cls

--- a/aquilia/manifest.py
+++ b/aquilia/manifest.py
@@ -1,15 +1,85 @@
 """
-AppManifest - Production-grade, data-driven application manifest system.
+AppManifest - Production-grade, data-driven application manifest system for Aquilia.
 
-No import-time side effects, fully serializable and inspectable.
-Provides precise control over middleware, sessions, DI, lifecycle, and error handling.
+This module provides the declarative metadata system used to describe the internal
+capabilities, dependencies, and structure of individual application modules. By keeping
+configuration declarative and decoupled from import-time execution, Aquilia prevents
+circular dependency side effects during bootstrapping.
 
-Architecture v2:
-- ComponentRef: Universal typed reference for all component kinds
-- ComponentKind: Enum for component classification
-- exports/imports: Cross-module provider visibility
-- auto_discover: Convention-over-configuration file scanning
-- guards/pipes/interceptors: First-class request pipeline components
+Architecture (Manifest-First Design)
+------------------------------------
+In Aquilia, application structure is split into two primary layers:
+1. **Global Orchestration (workspace.py)**: Configures global network settings, databases,
+   third-party integrations, and maps directory-level module pointers.
+2. **Module internals (manifest.py)**: Each module provides an `AppManifest` acting as the
+   definitive catalog of its controllers, services, middleware, models, database models,
+   realtime socket controllers, and lifecycle hooks.
+
+Registration & Discovery Flow
+-----------------------------
+During application initialization, the framework's scanner scans active modules:
+- **Convention-based Auto-discovery**: When `auto_discover=True` (default), the framework
+  scans convention directories (such as `/controllers`, `/services`, `/models`, etc.) matching
+  defined patterns and registers components automatically.
+- **Explicit Component Reference**: Components can also be explicitly declared using standard
+  import path strings (e.g. `"modules.users.services:UsersService"`) or `ComponentRef` instances
+  which offer metadata-based configuration.
+
+Resolution & DI Visibility Flow
+------------------------------
+Cross-module dependency visibility is governed by module boundaries:
+- **Imports**: Declares other modules that this module depends on.
+- **Exports**: Controls visibility of internal dependency injection (DI) service providers
+  to the rest of the application. Services not listed under `exports` remain private to
+  the module.
+
+Common Usage Patterns
+---------------------
+Declaring a basic module with convention-based discovery:
+
+```python
+from aquilia.manifest import AppManifest
+
+manifest = AppManifest(
+    name="billing",
+    version="1.2.0",
+    description="Manages subscriptions and invoices",
+    imports=["auth", "users"],
+    auto_discover=True,
+)
+```
+
+Advanced Usage Patterns
+-----------------------
+Declaring a complex module with custom DI service registration, priority middleware, and guards:
+
+```python
+from aquilia.manifest import AppManifest, ServiceConfig, MiddlewareConfig, ServiceScope
+
+manifest = AppManifest(
+    name="billing",
+    version="1.2.0",
+    services=[
+        ServiceConfig(
+            class_path="modules.billing.services:PaymentService",
+            scope=ServiceScope.REQUEST,
+            tag="stripe",
+            config={"api_key_env": "STRIPE_API_KEY"},
+        )
+    ],
+    middleware=[
+        MiddlewareConfig(
+            class_path="modules.billing.middleware:RateLimitMiddleware",
+            priority=10,
+            config={"limit": 60},
+        )
+    ],
+    guards=[
+        "modules.billing.guards:StripeSignatureGuard",
+    ],
+    exports=["modules.billing.services:PaymentService"],
+)
+```
 """
 
 import hashlib
@@ -29,7 +99,31 @@ from .typing.manifest import ManifestMetadata
 
 
 class ComponentKind(str, Enum):
-    """Classification of framework components for auto-discovery."""
+    """
+    Classification of framework components for auto-discovery and registration.
+
+    This enum defines all first-class component kinds supported by the Aquilia framework.
+    It is used by `ComponentRef` and convention-based discovery to classify components and
+    wire them correctly into the dependency injection container, routing engine, or middleware chain.
+
+    Attributes:
+        CONTROLLER: HTTP API controller managing route handlers.
+        SERVICE: Dependency injection service containing business logic.
+        MIDDLEWARE: ASGI or HTTP middleware in the request/response chain.
+        GUARD: Security/authorization check executing before controllers.
+        PIPE: Data transformation or validation layer for request payloads.
+        INTERCEPTOR: Aspect-oriented hook wrapping controller execution.
+        EFFECT: Contextual side-effect provider.
+        MODEL: Database schema model class.
+        FAULT_HANDLER: Exception translator for specific fault domains.
+        SOCKET_CONTROLLER: Realtime WebSocket message controller.
+        SERIALIZER: Data serialization/deserialization schema.
+        TASK: Asynchronous background worker task.
+        EVENT_HANDLER: Event listener in the pub/sub subsystem.
+        INTEGRATION: Third-party service integration config.
+        COMMAND: CLI command registered in the admin interface.
+        VALIDATOR: Request parameter validator.
+    """
 
     CONTROLLER = "controller"
     SERVICE = "service"
@@ -54,13 +148,37 @@ class ComponentRef:
     """
     Universal typed reference to any framework component.
 
-    Provides a unified format for referencing controllers, services,
-    middleware, guards, pipes, interceptors, and models.
-    Replaces the inconsistent mix of bare strings and config dataclasses.
+    Provides a unified format for referencing controllers, services, middleware,
+    guards, pipes, interceptors, and models. Replaces the inconsistent mix of
+    bare strings and configuration objects, enabling metadata passing at registration time.
+
+    Parameters:
+        class_path: Dotted module path and class name separated by a colon
+            (e.g., `"modules.users.controllers:UsersController"`).
+        kind: The classification of the component from `ComponentKind`.
+        metadata: Arbitrary key-value metadata associated with the component,
+            conforming to `ManifestMetadata`.
+
+    Raises:
+        ManifestInvalidFault: If the class_path is missing a colon `':'`.
 
     Examples:
-        ComponentRef("modules.users.controllers:UsersController", ComponentKind.CONTROLLER)
-        ComponentRef("modules.auth.guards:JWTGuard", ComponentKind.GUARD, metadata={"priority": 10})
+        Basic usage:
+        ```python
+        ref = ComponentRef(
+            class_path="modules.users.controllers:UsersController",
+            kind=ComponentKind.CONTROLLER
+        )
+        ```
+
+        With metadata:
+        ```python
+        ref = ComponentRef(
+            class_path="modules.auth.guards:JWTGuard",
+            kind=ComponentKind.GUARD,
+            metadata={"priority": 10}
+        )
+        ```
     """
 
     class_path: str  # "module.path:ClassName"
@@ -96,7 +214,20 @@ class ComponentRef:
 
 
 class ServiceScope(str, Enum):
-    """Service lifecycle scope."""
+    """
+    Service lifecycle scopes for dependency injection.
+
+    Defines the instantiation policy and lifespan of services resolved
+    by the dependency injection (DI) container.
+
+    Attributes:
+        SINGLETON: Application-wide single instance shared across all requests.
+        APP: Module-level single instance shared within the defining module.
+        REQUEST: Instantiated once per incoming HTTP/WebSocket request and disposed after.
+        TRANSIENT: Instantiated fresh every time the service is requested/injected.
+        POOLED: Managed object pool of reusable instances.
+        EPHEMERAL: High-performance transient instance without container tracking or hooks.
+    """
 
     SINGLETON = "singleton"  # App-level single instance
     APP = "app"  # Module-level single instance
@@ -108,7 +239,32 @@ class ServiceScope(str, Enum):
 
 @dataclass
 class LifecycleConfig:
-    """Lifecycle hook configuration."""
+    """
+    Lifecycle hook configuration for modules and services.
+
+    Allows registering custom startup and shutdown hooks, declaring dependency order,
+    and managing timeouts/errors during the application boot process.
+
+    Parameters:
+        on_startup: Dotted path to the callable executed during application bootstrap
+            (e.g., `"modules.users.hooks:init_db"`).
+        on_shutdown: Dotted path to the callable executed during application shutdown
+            (e.g., `"modules.users.hooks:close_db"`).
+        depends_on: List of other module names that must complete startup before this one.
+        startup_timeout: Maximum duration in seconds allowed for startup hook execution.
+        shutdown_timeout: Maximum duration in seconds allowed for shutdown hook execution.
+        error_strategy: Action taken if a hook fails. Must be `"propagate"`, `"log"`, or `"ignore"`.
+
+    Examples:
+        ```python
+        config = LifecycleConfig(
+            on_startup="modules.users.hooks:on_boot",
+            on_shutdown="modules.users.hooks:on_close",
+            depends_on=["auth"],
+            startup_timeout=15.0,
+        )
+        ```
+    """
 
     on_startup: str | None = None  # "path.to.module:function"
     on_shutdown: str | None = None  # "path.to.module:function"
@@ -131,7 +287,46 @@ class LifecycleConfig:
 
 @dataclass
 class ServiceConfig:
-    """Service registration configuration with complete DI support."""
+    """
+    Service registration configuration with complete DI support.
+
+    Declares explicit service parameters for registration in the dependency injection
+    container, enabling custom scopes, aliases, factories, and conditional flag checks.
+
+    Parameters:
+        class_path: Dotted module path and class name separated by a colon
+            (e.g., `"modules.users.services:UsersService"`).
+        scope: Lifecycle scope policy of the service. Defaults to `ServiceScope.APP`.
+        auto_discover: If `True`, automatically wires constructor dependencies.
+        lifecycle: Optional custom lifecycle hooks specifically for this service.
+        feature_flags: Service is only registered if all listed feature flags are active.
+        aliases: Alternative token strings that resolve to this service instance.
+        tag: Optional string identifier enabling named/tagged injection (`Inject(tag=...)`).
+        factory: Dotted path to a factory function used to instantiate the service.
+        factory_args: Dictionary of arguments passed directly to the factory function.
+        config: Dictionary of keyword arguments passed directly to the constructor.
+        observable: If `True`, publishes performance metrics and tracing spans.
+        required: If `True` (default), bootstrap fails if this service cannot be registered.
+
+    Examples:
+        Configuration with custom arguments:
+        ```python
+        config = ServiceConfig(
+            class_path="modules.users.services:UsersService",
+            scope=ServiceScope.SINGLETON,
+            config={"max_users": 1000}
+        )
+        ```
+
+        Using a factory function:
+        ```python
+        config = ServiceConfig(
+            class_path="modules.auth.services:AuthService",
+            factory="modules.auth.factories:create_auth_service",
+            factory_args={"env": "prod"}
+        )
+        ```
+    """
 
     class_path: str  # "path.to.module:ClassName"
     scope: ServiceScope = ServiceScope.APP  # Lifecycle scope
@@ -175,7 +370,37 @@ class ServiceConfig:
 
 @dataclass
 class MiddlewareConfig:
-    """Middleware registration configuration."""
+    """
+    Middleware registration configuration.
+
+    Declares a middleware component in the HTTP request/response pipeline, defining
+    its path, execution priority, active scope, and conditional parameters.
+
+    Parameters:
+        class_path: Dotted module path and class name separated by a colon
+            (e.g., `"modules.users.middleware:UsersMiddleware"`).
+        scope: Target routing scope. Must be `"global"` (runs on all routes),
+            `"app"` (runs on specific application routes), or `"route"` (runs on specific path patterns).
+        scope_target: Optional target modifier for scope (e.g. specific application name or path pattern).
+        priority: Execution priority order (lower executes earlier, default is `50`).
+        condition: Optional callable returning a boolean to determine if the middleware should run.
+        config: Dictionary of keyword arguments passed directly to the middleware constructor.
+        on_error: Recovery action if middleware execution fails. Must be `"propagate"`, `"skip"`, or `"fallback"`.
+        fallback: Optional dotted path to fallback middleware.
+        observable: If `True`, records execution duration metrics.
+        log_requests: If `True`, enables logging for incoming requests.
+        log_responses: If `True`, enables logging for outgoing responses.
+
+    Examples:
+        ```python
+        config = MiddlewareConfig(
+            class_path="aquilia.middleware:LoggingMiddleware",
+            scope="global",
+            priority=10,
+            config={"log_headers": True}
+        )
+        ```
+    """
 
     class_path: str  # "path.to.module:ClassName"
     scope: str = "global"  # "global", "app", "route"
@@ -209,7 +434,45 @@ class MiddlewareConfig:
 
 @dataclass
 class SessionConfig:
-    """Session management configuration."""
+    """
+    Session management configuration.
+
+    Defines cryptographic session policies, TTLs, transport methods (cookies or headers),
+    and storage backends (memory, redis, etc.) for a module.
+
+    Parameters:
+        name: Unique session policy name.
+        enabled: If `True` (default), enables session management for this module.
+        ttl: Time-to-live duration for active sessions. Defaults to `7 days`.
+        idle_timeout: Optional inactivity timeout duration.
+        renewal: Optional session renewal/refresh window duration.
+        transport: Protocol transport method. Must be `"cookie"`, `"header"`, or `"custom"`.
+        transport_config: Optional dictionary of transport-specific parameters.
+        cookie_name: Name of the session cookie. Defaults to `"session_id"`.
+        cookie_domain: Optional domain limitation for the session cookie.
+        cookie_path: URL path constraint for the session cookie. Defaults to `"/"`.
+        cookie_secure: If `True` (default), cookie is only sent over HTTPS.
+        cookie_httponly: If `True` (default), cookie is inaccessible to client-side scripts.
+        cookie_samesite: CSRF protection policy. Must be `"Strict"`, `"Lax"`, or `"None"`.
+        store: Storage engine type. Must be `"memory"`, `"redis"`, `"database"`, or `"custom"`.
+        store_config: Optional dictionary of storage engine parameters.
+        encryption_enabled: If `True`, session data is encrypted at rest/transit.
+        encryption_key_env: Environment variable holding the cryptographic secret key.
+        serializer: Session serialization format. Must be `"json"`, `"pickle"`, or `"msgpack"`.
+        log_lifecycle: If `True`, logs session creation and destruction events.
+        metrics_enabled: If `True`, collects session metrics.
+
+    Examples:
+        ```python
+        config = SessionConfig(
+            name="user_session",
+            ttl=timedelta(days=1),
+            cookie_secure=True,
+            store="redis",
+            store_config={"redis_url": "redis://localhost:6379/1"}
+        )
+        ```
+    """
 
     name: str  # Session policy name
     enabled: bool = True  # Enable/disable
@@ -260,7 +523,27 @@ class SessionConfig:
 
 @dataclass
 class FaultHandlerConfig:
-    """Fault handler configuration."""
+    """
+    Fault handler configuration for specific exception domains.
+
+    Maps a structured framework fault domain (e.g. `"AUTH"`, `"VALIDATION"`) to an
+    exception handler callable, and defines error recovery strategies.
+
+    Parameters:
+        domain: Target fault domain name.
+        handler_path: Dotted path to the handler function (e.g. `"modules.auth.handlers:on_auth_fault"`).
+        recovery_strategy: Strategy to use. Must be `"propagate"`, `"recover"`, or `"fallback"`.
+        fallback_response: Optional JSON-serializable dictionary returned on fallback.
+
+    Examples:
+        ```python
+        handler = FaultHandlerConfig(
+            domain="VALIDATION",
+            handler_path="modules.users.handlers:handle_validation_error",
+            recovery_strategy="recover"
+        )
+        ```
+    """
 
     domain: str  # Fault domain (e.g., "AUTH", "VALIDATION")
     handler_path: str  # "path.to.module:handler_function"
@@ -270,7 +553,31 @@ class FaultHandlerConfig:
 
 @dataclass
 class FaultHandlingConfig:
-    """Fault/error handling configuration."""
+    """
+    Module-level fault and error handling configuration.
+
+    Aggregates fault domain handlers, exception translation middleware, and metrics.
+
+    Parameters:
+        default_domain: Fallback fault domain name when none is matched. Defaults to `"APP"`.
+        strategy: Default recovery action if a handler is not defined. Defaults to `"propagate"`.
+        handlers: List of explicit domain handlers using `FaultHandlerConfig`.
+        middlewares: List of custom error middleware instances.
+        metrics_enabled: If `True`, tracks error counts and rates.
+
+    Examples:
+        ```python
+        config = FaultHandlingConfig(
+            default_domain="BILLING",
+            handlers=[
+                FaultHandlerConfig(
+                    domain="STRIPE",
+                    handler_path="modules.billing.handlers:handle_stripe_error"
+                )
+            ]
+        )
+        ```
+    """
 
     default_domain: str = "APP"  # Default fault domain
     strategy: str = "propagate"  # "propagate", "recover", "fallback"
@@ -290,7 +597,33 @@ class FaultHandlingConfig:
 
 @dataclass
 class FeatureConfig:
-    """Feature flag configuration."""
+    """
+    Feature flag configuration for conditional component activation.
+
+    Allows wrapping services, controllers, middleware, and routes with a feature
+    toggle, enabling dynamic module composition based on runtime conditions.
+
+    Parameters:
+        name: Unique feature flag identifier string.
+        enabled: If `True`, the feature is enabled by default. Defaults to `False`.
+        conditions: Dictionary of rules (e.g. env vars, customer tier) required to enable.
+        services: List of service class path strings only registered when the feature is active.
+        controllers: List of controller path strings only registered when feature is active.
+        middleware: List of middleware configurations only active when feature is active.
+        routes: List of routes only registered when feature is active.
+        log_usage: If `True`, logs feature evaluation events.
+        metrics_enabled: If `True`, collects usage metrics.
+
+    Examples:
+        ```python
+        feature = FeatureConfig(
+            name="beta-billing",
+            enabled=False,
+            conditions={"env": "staging"},
+            services=["modules.billing.services:BetaBillingService"]
+        )
+        ```
+    """
 
     name: str  # Feature identifier
     enabled: bool = False  # Default state
@@ -354,7 +687,29 @@ class BackgroundTaskConfig:
 
 @dataclass
 class TemplateConfig:
-    """Template engine configuration."""
+    """
+    Jinja2-based template engine configuration for a module.
+
+    Defines search paths, caching mechanisms, precompilation policies, and
+    context processors for rendering HTML/text templates.
+
+    Parameters:
+        enabled: If `True` (default), enables template rendering for this module.
+        search_paths: List of directory paths (relative to module root) containing templates.
+        precompile: If `True`, compiles all templates at application boot time for faster response.
+        cache: Caching backend. Must be `"memory"`, `"surp"`, or `"none"`.
+        sandbox: If `True` (default), uses a secure sandboxed Jinja environment to prevent arbitrary code execution.
+        context_processors: List of dotted path strings to callables returning template global context.
+
+    Examples:
+        ```python
+        config = TemplateConfig(
+            search_paths=["templates", "layouts"],
+            cache="memory",
+            sandbox=True
+        )
+        ```
+    """
 
     enabled: bool = True
     search_paths: list[str] = field(default_factory=list)
@@ -377,8 +732,19 @@ class DatabaseConfig:
     """
     DEPRECATED: Manifest-level database configuration.
 
-    Use Workspace.database() / Integration.database() instead.
-    This class is retained only for backward compatibility.
+    This class is retained only for backward compatibility. Use `Workspace.database()`
+    or `Integration.database()` inside `workspace.py` instead.
+
+    Parameters:
+        url: Database connection string.
+        auto_connect: Connect on startup.
+        auto_create: Automatically create database tables.
+        auto_migrate: Automatically execute pending migrations.
+        migrations_dir: Directory containing migration scripts.
+        pool_size: Connection pool size.
+        echo: Log generated SQL queries.
+        model_paths: Explicit list of database model paths.
+        scan_dirs: Directories scanned for model discovery.
     """
 
     url: str = "sqlite:///db.sqlite3"  # Database URL
@@ -418,7 +784,49 @@ class DatabaseConfig:
 
 @dataclass
 class AppVersioningConfig:
-    """Module-level versioning override configuration."""
+    """
+    Module-level versioning override configuration.
+
+    Enables version negotiation, route prefixing, and deprecation scheduling
+    specifically for API routes defined in this module.
+
+    Parameters:
+        strategy: Negotiation strategy. Must be `"header"`, `"url"`, `"query"`, `"media_type"`, `"channel"`, or `"composite"`.
+        versions: List of supported version identifier strings (e.g. `["v1", "v2"]`).
+        default_version: Version used when none is provided in the client request.
+        require_version: If `True`, requests without version info are rejected with a fault.
+        header_name: HTTP header name for versioning (used with strategy `"header"`). Defaults to `"X-API-Version"`.
+        query_param: Query parameter name for versioning. Defaults to `"api_version"`.
+        url_prefix: Prefix used for URL path segment versioning. Defaults to `"v"`.
+        url_segment_index: Index of URL segment containing version. Defaults to `0`.
+        strip_version_from_path: If `True`, removes version segment from request path before routing.
+        url_position: Position of the version segment in URL. Must be `"before"` or `"after"`.
+        expose_unversioned_alias: If `True`, exposes routes without a version prefix.
+        media_type_param: Media type version parameter. Defaults to `"version"`.
+        channels: Dictionary mapping channel names to versions.
+        channel_header: HTTP header name for channel identifier.
+        channel_query_param: Query parameter name for channel identifier.
+        negotiation_mode: Negotiation behavior. Must be `"exact"`, `"compatible"`, `"best_match"`, or `"latest"`.
+        sunset_policy: Optional sunset/deprecation policy metadata object.
+        sunset_schedules: Dictionary containing sunset schedule dates per version.
+        include_version_header: If `True`, includes version header in responses.
+        response_header_name: Name of the response version header. Defaults to `"X-API-Version"`.
+        include_supported_versions_header: If `True`, includes supported versions header in response.
+        neutral_paths: List of route paths exempt from version requirements.
+        enabled: If `True` (default), enables versioning for this module.
+        auto_version_unmarked: If `True`, automatically versions routes without explicit decorator tags.
+        position: Convenience alias for `url_position`.
+
+    Examples:
+        ```python
+        config = AppVersioningConfig(
+            strategy="url",
+            versions=["v1", "v2"],
+            default_version="v2",
+            require_version=True
+        )
+        ```
+    """
 
     strategy: str = "header"
     versions: list[str] = field(default_factory=list)
@@ -506,7 +914,41 @@ def versioning(
     enabled: bool = True,
     **kwargs: Any,
 ) -> dict[str, Any]:
-    """Configure API versioning integration at module manifest level."""
+    """
+    Configure API versioning integration at the module manifest level.
+
+    Helper function returning a dictionary structure matching `AppVersioningConfig`
+    parameters, providing backward-compatible syntax for configuration blocks.
+
+    Parameters:
+        strategy: Negotiation strategy. Must be `"header"`, `"url"`, `"query"`, `"media_type"`, `"channel"`, or `"composite"`.
+        versions: List of supported version identifier strings.
+        default_version: Version used when none is provided in the client request.
+        require_version: If `True`, requests without version info are rejected with a fault.
+        header_name: HTTP header name for versioning. Defaults to `"X-API-Version"`.
+        query_param: Query parameter name for versioning. Defaults to `"api_version"`.
+        url_prefix: Prefix used for URL path segment versioning. Defaults to `"v"`.
+        url_segment_index: Index of URL segment containing version. Defaults to `0`.
+        strip_version_from_path: If `True`, removes version segment from request path.
+        url_position: Position of the version segment in URL. Must be `"before"` or `"after"`.
+        expose_unversioned_alias: If `True`, exposes routes without a version prefix.
+        media_type_param: Media type version parameter. Defaults to `"version"`.
+        channels: Dictionary mapping channel names to versions.
+        channel_header: HTTP header name for channel identifier.
+        channel_query_param: Query parameter name for channel identifier.
+        negotiation_mode: Negotiation behavior. Must be `"exact"`, `"compatible"`, `"best_match"`, or `"latest"`.
+        sunset_policy: Optional sunset/deprecation policy metadata object.
+        sunset_schedules: Dictionary containing sunset schedule dates per version.
+        include_version_header: If `True`, includes version header in responses.
+        response_header_name: Name of the response version header. Defaults to `"X-API-Version"`.
+        include_supported_versions_header: If `True`, includes supported versions header in response.
+        neutral_paths: List of route paths exempt from version requirements.
+        enabled: If `True` (default), enables versioning for this module.
+        **kwargs: Extensible extra arguments.
+
+    Returns:
+        Dictionary containing all structured versioning settings.
+    """
     config: dict[str, Any] = {
         "enabled": enabled,
         "strategy": strategy,
@@ -543,22 +985,77 @@ class AppManifest:
     """
     Production-grade application manifest for complete app configuration.
 
-    Architecture v2 additions:
-    - exports/imports: Cross-module provider visibility
-    - guards/pipes/interceptors: First-class request pipeline components
-    - auto_discover: Convention-over-configuration file scanning
-    - All component lists accept Union[str, ComponentRef] for flexibility
+    The primary entry point for declaring a module's internal assets, wiring, and
+    dependencies. It maps controllers, services, database models, background tasks,
+    middleware, request pipeline guards, pipes, and interceptors.
 
-    Provides precise control over:
-    - Services with DI scopes and lifecycle
-    - Controllers with routing
-    - Middleware with scoping and priority
-    - Guards for authentication/authorization gates
-    - Pipes for request data transformation/validation
-    - Interceptors for cross-cutting concerns (logging, caching, etc.)
-    - Sessions with policies and storage
-    - Error handling with fault domains
-    - Feature flags with conditional activation
+    In the Manifest-First Design:
+    1. Each module contains a `manifest.py` containing an `AppManifest` instance (by convention).
+    2. During boot, the framework scans modules to load manifests and build a dependency graph.
+    3. Manifest parameters are normalized, validated, and resolved at runtime.
+
+    Parameters:
+        name: Unique module identifier (alphanumeric with underscores).
+        version: Semantic version of the module.
+        description: Concise summary of what the module does.
+        author: Developer/Owner email or name.
+        services: List of services to register in the DI container.
+            Can contain strings, `ServiceConfig` instances, or `ComponentRef` objects.
+        controllers: List of HTTP controller classes or `ComponentRef` objects.
+        socket_controllers: List of WebSocket controller classes or `ComponentRef` objects.
+        models: List of model classes or `ComponentRef` objects.
+        serializers: List of serializer classes or `ComponentRef` objects.
+        guards: List of authorization guard class paths or `ComponentRef` objects.
+        pipes: List of request data validation pipe class paths or `ComponentRef` objects.
+        interceptors: List of aspect-oriented interceptor class paths or `ComponentRef` objects.
+        middleware: List of middleware configs, class paths, or `ComponentRef` objects.
+        route_prefix: DEPRECATED: Module route prefix (use `Module.route_prefix()` in `workspace.py`).
+        base_path: Optional base directory override for file imports.
+        lifecycle: Module startup/shutdown lifecycle configs (`LifecycleConfig`).
+        sessions: List of session policy configurations (`SessionConfig`).
+        templates: Jinja template engine configuration (`TemplateConfig`).
+        database: DEPRECATED: Module database configuration. Use `Workspace.database()` instead.
+        faults: Fault handling configuration (`FaultHandlingConfig`).
+        background_tasks: Background task queue declarations (`BackgroundTaskConfig`).
+        features: Feature toggle configurations (`FeatureConfig`).
+        exports: List of service class names exported to importing modules.
+        imports: List of module names this module depends on.
+        depends_on: Legacy alias for `imports`.
+        tags: List of organizational tags.
+        versioning: Version negotiation parameters (`AppVersioningConfig`).
+        config_schema: Optional JSON Schema dictionary to validate module configuration.
+        auto_discover: If `True` (default), scans directories matching `discover_patterns`.
+        discover_patterns: Folders to scan during auto-discovery.
+        middlewares: Legacy middleware format.
+        default_fault_domain: Legacy fault domain.
+        on_startup: Legacy startup callable.
+        on_shutdown: Legacy shutdown callable.
+        config: Legacy config class.
+
+    Raises:
+        ManifestInvalidFault: If name or version is missing, or name is invalid.
+
+    Examples:
+        Declaring a billing module:
+        ```python
+        from aquilia.manifest import AppManifest, ServiceConfig, ServiceScope
+
+        manifest = AppManifest(
+            name="billing",
+            version="1.0.0",
+            services=[
+                ServiceConfig(
+                    class_path="modules.billing.services:BillingService",
+                    scope=ServiceScope.SINGLETON
+                )
+            ],
+            controllers=[
+                "modules.billing.controllers:BillingController"
+            ],
+            imports=["auth", "users"],
+            exports=["modules.billing.services:BillingService"]
+        )
+        ```
     """
 
     # Identity

--- a/aquilia/pyconfig.py
+++ b/aquilia/pyconfig.py
@@ -161,6 +161,12 @@ class Secret:
         self._default: str | None = default
         self._required: bool = required
 
+        if env is None and value is not None:
+            import re
+
+            if isinstance(value, str) and re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", value):
+                self._env_name = value
+
     def reveal(self) -> str | None:
         """
         Return the actual secret value (use deliberately).

--- a/aquilia/sessions/engine.py
+++ b/aquilia/sessions/engine.py
@@ -27,6 +27,7 @@ from .faults import (
     SessionIdleTimeoutFault,
     SessionInvalidFault,
     SessionRotationFailedFault,
+    SessionStoreCorruptedFault,
     SessionStoreUnavailableFault,
 )
 
@@ -131,6 +132,12 @@ class SessionEngine:
                 self.logger.warning(f"Session fingerprint mismatch (possible hijack): {session_id_str[:16]}...")
                 self._emit_event("session_fingerprint_mismatch", None, request)
 
+            except SessionStoreCorruptedFault:
+                # Degrade gracefully like every other invalid-session case
+                # instead of crashing the request on a corrupted store record.
+                self.logger.warning(f"Corrupted session record: {session_id_str[:16]}...")
+                self._emit_event("session_corrupted", None, request)
+
         # Phase 2: Resolution - Create new session
         session = await self._create_new(now, request)
         self._emit_event("session_created", session, request)
@@ -211,6 +218,13 @@ class SessionEngine:
 
         session._policy_name = self.policy.name
 
+        # `flags` is a plain set, not the dirty-tracked `data` dict -- mutating
+        # it in place above does NOT mark the session dirty. Without this,
+        # commit() sees is_dirty=False and never calls store.save(), so a
+        # freshly created (non-fingerprint-bound) session is never persisted
+        # even though the response cookie is issued for it unconditionally.
+        session.mark_dirty()
+
         # Bind fingerprint if policy requires it (OWASP)
         if self.policy.fingerprint_binding and request:
             client_ip = ""
@@ -236,9 +250,18 @@ class SessionEngine:
         """
         Commit session changes (Phase 6-7: Commit, Emission).
 
-        FIX: Concurrency check happens BEFORE save (not after).
+        FIX: Concurrency check happens BEFORE rotation and save (not after).
+        Rotation deletes the OLD session from the store as part of assigning
+        a new ID -- if the concurrency check ran after rotation and then
+        rejected the commit, the old session would already be gone with the
+        new one never persisted, leaving the caller with no valid session at
+        all. Checking concurrency first means a rejected commit leaves the
+        pre-existing session untouched.
         """
         now = datetime.now(timezone.utc)
+
+        if privilege_changed and session.is_authenticated:
+            await self.check_concurrency(session)
 
         # Check if rotation needed
         if self.policy.should_rotate(session, privilege_changed):
@@ -252,10 +275,6 @@ class SessionEngine:
                     new_id="unknown",
                     cause=str(e),
                 )
-
-        # FIX: Check concurrency BEFORE save (was after save in original)
-        if privilege_changed and session.is_authenticated:
-            await self.check_concurrency(session)
 
         # Persist if needed
         if self.policy.should_persist(session) and session.is_dirty:

--- a/aquilia/sessions/store.py
+++ b/aquilia/sessions/store.py
@@ -107,7 +107,8 @@ class MemoryStore:
                         del self._principal_index[principal_id]
 
     async def exists(self, session_id: SessionID) -> bool:
-        return str(session_id) in self._sessions
+        async with self._lock:
+            return str(session_id) in self._sessions
 
     async def list_by_principal(self, principal_id: str) -> list[Session]:
         async with self._lock:
@@ -257,8 +258,9 @@ class FileStore:
     async def delete(self, session_id: SessionID) -> None:
         path = self._get_path(session_id)
         try:
-            if path.exists():
-                path.unlink()
+            async with self._lock:
+                if path.exists():
+                    path.unlink()
         except Exception as e:
             raise SessionStoreUnavailableFault(store_name="file", cause=str(e))
 

--- a/aquilia/templates/auth_integration.py
+++ b/aquilia/templates/auth_integration.py
@@ -221,9 +221,26 @@ def create_auth_helpers(identity: Optional["Identity"] = None, authz_engine: Opt
             return False
 
         try:
-            # Simplified permission check
-            # Real implementation would use authz_engine.check()
-            return True  # Placeholder
+            from aquilia.auth.authz import AuthzContext, Decision
+
+            if hasattr(identity, "get_attribute"):
+                scopes = identity.get_attribute("scopes", []) or []
+                roles = identity.get_attribute("roles", []) or []
+            else:
+                attrs = getattr(identity, "attributes", {}) or {}
+                scopes = attrs.get("scopes", []) or []
+                roles = attrs.get("roles", []) or []
+
+            authz_ctx = AuthzContext(
+                identity=identity,
+                resource=str(resource) if resource is not None else "",
+                action=permission,
+                scopes=list(scopes),
+                roles=list(roles),
+                tenant_id=getattr(identity, "tenant_id", None),
+            )
+            result = authz_engine.rbac.check(authz_ctx, permission)
+            return result.decision == Decision.ALLOW
         except Exception as e:
             logger.warning(f"Permission check failed: {e}")
             return False
@@ -243,7 +260,7 @@ def create_auth_helpers(identity: Optional["Identity"] = None, authz_engine: Opt
         if not owner_id:
             return False
 
-        return str(owner_id) == str(identity.identity_id)
+        return str(owner_id) == str(identity.id)
 
     return {
         "is_authenticated": is_authenticated,

--- a/aquilia/workspace.py
+++ b/aquilia/workspace.py
@@ -478,6 +478,10 @@ class Workspace:
         if isinstance(integration, IntegrationConfig):
             integration = integration.to_dict()
 
+        from aquilia.integrations.utils import resolve_config_value
+
+        integration = resolve_config_value(integration)
+
         integration_type = integration.get("_integration_type")
         if integration_type:
             self._integrations[integration_type] = integration
@@ -822,7 +826,9 @@ class Workspace:
                 config["integrations"] = {}
             config["integrations"]["inspector"] = self._inspector_config
 
-        return config
+        from aquilia.integrations.utils import resolve_config_value
+
+        return resolve_config_value(config)
 
     def __repr__(self) -> str:
         return f"Workspace(name='{self._name}', version='{self._version}', modules={len(self._modules)})"

--- a/aquilia/workspace.py
+++ b/aquilia/workspace.py
@@ -1,26 +1,87 @@
 """
-Aquilia Workspace Configuration.
+Aquilia Workspace Configuration & Orchestration System.
 
-Provides the ``Workspace`` and ``Module`` fluent builders together with
-their supporting dataclasses (``RuntimeConfig``, ``ModuleConfig``,
-``AuthConfig``).  These were previously housed in ``config_builders.py``
-alongside the legacy ``Integration`` class; they now live in their own
-clean, focused module.
+This module provides the core fluent builders and orchestration configuration data structures
+that define the application's global deployment parameters.
 
-Usage::
+Architecture (Manifest-First Design)
+------------------------------------
+In Aquilia, workspace.py is the primary coordinator and orchestration layer:
+- **Global Orchestration**: Configures mode, server binding details, telemetry, security headers,
+  global databases, background workers, and mail/cache servers.
+- **Module Pointers**: Registers active application modules by defining pointers (`Module`).
+  Internals of the modules (controllers, services) remain in each module's `manifest.py`.
+- **Integrations**: Binds third-party integrations (e.g. databases, caches, mailing services)
+  to the workspace, passing credentials, connection limits, and provider specifics.
 
-    from aquilia.workspace import Workspace, Module
+Registration & Discovery Flow
+-----------------------------
+1. **Workspace Definition**: The developer builds the `Workspace` configuration in the project's
+   root configuration module (typically `workspace.py`).
+2. **Integration Hooking**: Integrations like `MailIntegration` or `DatabaseIntegration` are
+   bound to the workspace using the fluent `.integrate()` method.
+3. **Module Registration**: Individual application modules are added via `.module(Module("name"))`.
+4. **Bootstrapping**: The framework scans the workspace, loads individual module manifests,
+   auto-discovers annotated components within convention folders, resolves environment settings,
+   and injects everything into the dependency injection container.
 
-    workspace = (
-        Workspace("myapp", version="1.0.0")
-        .runtime(mode="dev", port=8000)
-        .module(
-            Module("users")
-            .route_prefix("/users")
-            .depends_on("auth")
-        )
-        .integrate(CacheIntegration(backend="redis"))
+Resolution & Configuration Handling
+-----------------------------------
+All integration arguments are recursively evaluated during serialization or bootstrap.
+`Env`, `Secret`, and `PyConfig` instances (e.g. `ProdEnv.mail.email_user`) are automatically resolved
+to primitive values (strings, integers) prior to instantiating provider objects.
+
+Common Usage Patterns
+---------------------
+Creating a basic development workspace:
+
+```python
+from aquilia.workspace import Workspace, Module
+
+workspace = (
+    Workspace("my-app", version="1.0.0")
+    .runtime(mode="dev", port=8000)
+    .module(Module("auth"))
+    .module(Module("users").route_prefix("/users").depends_on("auth"))
+)
+```
+
+Advanced Usage Patterns
+-----------------------
+Creating a production-grade workspace with database, caching, and template engine configuration:
+
+```python
+from aquilia.workspace import Workspace, Module
+from aquilia.integrations import DatabaseIntegration, SQLiteProvider, MailIntegration, SMTPProvider
+from aquilia.pyconfig import Env, Secret
+
+workspace = (
+    Workspace("billing-platform", version="1.0.0")
+    .runtime(mode="prod", host="0.0.0.0", port=8080)
+    .database(
+        url=Env("DATABASE_URL"),
+        auto_migrate=True,
     )
+    .integrate(
+        MailIntegration(
+            default_from="noreply@billing.com",
+            providers=[
+                SMTPProvider(
+                    host=Env("SMTP_HOST"),
+                    port=Env("SMTP_PORT", cast=int),
+                    username=Env("SMTP_USER"),
+                    password=Secret("SMTP_PASS")
+                )
+            ]
+        )
+    )
+    .module(
+        Module("billing")
+        .route_prefix("/api/v1/billing")
+        .tags("billing", "payments")
+    )
+)
+```
 """
 
 from __future__ import annotations
@@ -37,7 +98,29 @@ from aquilia.integrations._protocol import IntegrationConfig
 
 @dataclass
 class RuntimeConfig:
-    """Runtime configuration."""
+    """
+    Global server runtime configuration.
+
+    Defines execution mode (development vs production), network bindings, reload policies,
+    and concurrent ASGI workers.
+
+    Parameters:
+        mode: Execution environment. Typically `"dev"`, `"test"`, or `"prod"`. Defaults to `"dev"`.
+        host: IP address or hostname to bind the ASGI server to. Defaults to `"127.0.0.1"`.
+        port: Network port to bind the ASGI server to. Defaults to `8000`.
+        reload: If `True`, restarts the server automatically when source files change (dev only). Defaults to `True`.
+        workers: Number of child worker processes to spawn. Defaults to `1`.
+
+    Examples:
+        ```python
+        config = RuntimeConfig(
+            mode="prod",
+            host="0.0.0.0",
+            port=443,
+            workers=4
+        )
+        ```
+    """
 
     mode: str = "dev"
     host: str = "127.0.0.1"
@@ -49,21 +132,39 @@ class RuntimeConfig:
 @dataclass
 class ModuleConfig:
     """
-    Module configuration -- workspace-level orchestration metadata.
+    Workspace-level module orchestration metadata.
 
-    The Module in workspace.py is a **pointer** to the per-module manifest.
-    Component declarations (controllers, services, middleware, models,
-    serializers, socket_controllers) live exclusively in each module's
-    ``manifest.py`` via ``AppManifest``.
+    A pointer configuration mapping how a module is bound into the workspace. It specifies
+    routing prefixes, cross-module dependencies, custom lifecycle hooks, database configurations,
+    and auto-discovery scanning toggles.
 
-    This dataclass holds only the orchestration concerns that the
-    workspace needs to know about:
-    - Identity (name, version)
-    - Routing topology (route_prefix, depends_on)
-    - Organisational metadata (tags, description, fault_domain)
-    - Discovery behaviour (auto_discover)
-    - Lifecycle hooks (on_startup, on_shutdown)
-    - Per-module database override
+    In the Manifest-First Architecture, `ModuleConfig` represents the orchestration pointer
+    registered in `workspace.py`, while component-level details (controllers, services) reside
+    in the module's own `manifest.py`.
+
+    Parameters:
+        name: Unique module folder and registration name.
+        version: Module version. Defaults to `"0.1.0"`.
+        description: Brief module summary.
+        fault_domain: Custom fault domain for exception translation. Defaults to uppercase `name`.
+        route_prefix: Base HTTP path prefix for module controller routes. Defaults to `"/{name}"`.
+        depends_on: List of other module names that must start up before this module.
+        tags: Categorization tags.
+        imports: List of module names whose exported services are visible to this module.
+        exports: List of service class names exported to other importing modules.
+        on_startup: Optional dotted path string to startup hook function.
+        on_shutdown: Optional dotted path string to shutdown hook function.
+        database: Optional dictionary overriding the global database configuration for this module.
+        auto_discover: If `True` (default), scans the module directory for convention components.
+
+    Examples:
+        ```python
+        config = ModuleConfig(
+            name="users",
+            route_prefix="/api/users",
+            depends_on=["auth"]
+        )
+        ```
     """
 
     name: str
@@ -111,45 +212,36 @@ class ModuleConfig:
 
 class Module:
     """
-    Fluent module builder -- workspace-level orchestration only.
+    Fluent builder class to configure a workspace module pointer.
 
-    The Module builder configures **how** a module fits into the workspace
-    (routing, dependencies, tags, lifecycle). All component declarations
-    (controllers, services, middleware, models, serializers) belong in the
-    module's own ``manifest.py`` via ``AppManifest``.
+    Defines routing prefixes, module boundaries (imports/exports), database connections,
+    and hooks for a specific module within the workspace configuration.
 
-    This separation follows the Manifest-First Architecture:
-    - ``workspace.py`` → orchestration & integration config
-    - ``modules/*/manifest.py`` → module internals (source of truth)
+    Examples:
+        Basic usage:
+        ```python
+        module = Module("billing").route_prefix("/billing").depends_on("auth")
+        ```
 
-    Example::
-
-        # workspace.py -- pointer only
-        workspace = (
-            Workspace("myapp")
-            .module(
-                Module("users", version="0.1.0")
-                .route_prefix("/users")
-                .depends_on("auth")
-                .tags("core", "users")
-            )
-            .module(
-                Module("auth", version="0.1.0")
-                .route_prefix("/auth")
-            )
+        Advanced custom database setup:
+        ```python
+        module = (
+            Module("analytics")
+            .database(url="postgresql://db/analytics_prod")
+            .auto_discover(False)
         )
-
-        # modules/users/manifest.py -- source of truth
-        manifest = AppManifest(
-            name="users",
-            version="0.1.0",
-            controllers=["modules.users.controllers:UsersController"],
-            services=["modules.users.services:UsersService"],
-            ...
-        )
+        ```
     """
 
     def __init__(self, name: str, version: str = "0.1.0", description: str = ""):
+        """
+        Initialize the Module fluent builder.
+
+        Parameters:
+            name: Unique module directory and registry name.
+            version: Semantic version of the module. Defaults to `"0.1.0"`.
+            description: Concise module description.
+        """
         self._config = ModuleConfig(
             name=name,
             version=version,
@@ -158,37 +250,107 @@ class Module:
         )
 
     def auto_discover(self, enabled: bool = True) -> Module:
+        """
+        Toggle convention-based auto-discovery scanning for this module.
+
+        Parameters:
+            enabled: If `True` (default), the framework scans folders matching convention
+                names (e.g. controllers, services, models) during bootstrap.
+
+        Returns:
+            The current `Module` builder instance for chaining.
+        """
         self._config.auto_discover = enabled
         return self
 
     def fault_domain(self, domain: str) -> Module:
+        """
+        Configure a custom fault domain name for exceptions originating in this module.
+
+        Parameters:
+            domain: Target fault domain name.
+
+        Returns:
+            The current `Module` builder instance for chaining.
+        """
         self._config.fault_domain = domain
         return self
 
     def route_prefix(self, prefix: str) -> Module:
+        """
+        Set the base HTTP path prefix for all routes defined in this module.
+
+        Parameters:
+            prefix: URL path prefix (e.g. `"/users"`).
+
+        Returns:
+            The current `Module` builder instance for chaining.
+        """
         self._config.route_prefix = prefix
         return self
 
     def depends_on(self, *modules: str) -> Module:
+        """
+        Declare bootstrap dependencies for this module.
+
+        Guarantees that the listed modules complete their startup sequence before
+        this module starts.
+
+        Parameters:
+            *modules: Variadic list of module names.
+
+        Returns:
+            The current `Module` builder instance for chaining.
+        """
         self._config.depends_on = list(modules)
         return self
 
     def imports(self, *modules: str) -> Module:
+        """
+        Define module imports to allow accessing exported services.
+
+        Parameters:
+            *modules: Variadic list of module names to import.
+
+        Returns:
+            The current `Module` builder instance for chaining.
+        """
         self._config.imports = list(modules)
         self._config.depends_on = list(modules)
         return self
 
     def exports(self, *components: str) -> Module:
+        """
+        Expose internal module services to other importing modules.
+
+        Parameters:
+            *components: Variadic list of service class name strings (e.g. `"UsersService"`).
+
+        Returns:
+            The current `Module` builder instance for chaining.
+        """
         self._config.exports = list(components)
         return self
 
     def tags(self, *module_tags: str) -> Module:
+        """
+        Assign metadata tags to this module.
+
+        Parameters:
+            *module_tags: Variadic list of string tags.
+
+        Returns:
+            The current `Module` builder instance for chaining.
+        """
         self._config.tags = list(module_tags)
         return self
 
     # ── Legacy registration methods (DEPRECATED) ───────────────────
 
     def register_controllers(self, *controllers: str) -> Module:
+        """
+        DEPRECATED: Register controllers. Declare them in AppManifest instead.
+        """
         import warnings
 
         warnings.warn(
@@ -200,6 +362,9 @@ class Module:
         return self
 
     def register_services(self, *services: str) -> Module:
+        """
+        DEPRECATED: Register services. Declare them in AppManifest instead.
+        """
         import warnings
 
         warnings.warn(
@@ -211,6 +376,9 @@ class Module:
         return self
 
     def register_providers(self, *providers: dict[str, Any]) -> Module:
+        """
+        DEPRECATED: Register providers. Declare them in AppManifest instead.
+        """
         import warnings
 
         warnings.warn(
@@ -221,6 +389,9 @@ class Module:
         return self
 
     def register_routes(self, *routes: dict[str, Any]) -> Module:
+        """
+        DEPRECATED: Register routes. Declare them in controllers instead.
+        """
         import warnings
 
         warnings.warn(
@@ -231,6 +402,9 @@ class Module:
         return self
 
     def register_sockets(self, *sockets: str) -> Module:
+        """
+        DEPRECATED: Register sockets. Declare them in AppManifest instead.
+        """
         import warnings
 
         warnings.warn(
@@ -242,6 +416,9 @@ class Module:
         return self
 
     def register_middlewares(self, *middlewares: str) -> Module:
+        """
+        DEPRECATED: Register middleware. Declare them in AppManifest instead.
+        """
         import warnings
 
         warnings.warn(
@@ -253,6 +430,9 @@ class Module:
         return self
 
     def register_models(self, *models: str) -> Module:
+        """
+        DEPRECATED: Register database models. Declare them in AppManifest instead.
+        """
         import warnings
 
         warnings.warn(
@@ -264,6 +444,9 @@ class Module:
         return self
 
     def register_serializers(self, *serializers: str) -> Module:
+        """
+        DEPRECATED: Register serializers. Declare them in AppManifest instead.
+        """
         import warnings
 
         warnings.warn(
@@ -275,10 +458,28 @@ class Module:
         return self
 
     def on_startup(self, hook: str) -> Module:
+        """
+        Register a custom startup hook callable.
+
+        Parameters:
+            hook: Dotted path to the callable function (e.g. `"modules.users.hooks:on_startup"`).
+
+        Returns:
+            The current `Module` builder instance for chaining.
+        """
         self._config.on_startup = hook
         return self
 
     def on_shutdown(self, hook: str) -> Module:
+        """
+        Register a custom shutdown hook callable.
+
+        Parameters:
+            hook: Dotted path to the callable function (e.g. `"modules.users.hooks:on_shutdown"`).
+
+        Returns:
+            The current `Module` builder instance for chaining.
+        """
         self._config.on_shutdown = hook
         return self
 
@@ -293,6 +494,21 @@ class Module:
         migrations_dir: str = "migrations",
         **kwargs,
     ) -> Module:
+        """
+        Configure a custom database connection specifically for this module.
+
+        Parameters:
+            url: Database connection string URL.
+            config: Optional config object to extract connection parameters from.
+            auto_connect: Connect automatically during bootstrap.
+            auto_create: Create schema tables automatically if missing.
+            auto_migrate: Execute pending migration scripts.
+            migrations_dir: Folder containing migration files.
+            **kwargs: Extra database connection keyword arguments.
+
+        Returns:
+            The current `Module` builder instance for chaining.
+        """
         if config is not None:
             db_dict = config.to_dict()
             db_dict.update(
@@ -317,7 +533,12 @@ class Module:
         return self
 
     def build(self) -> ModuleConfig:
-        """Build module configuration."""
+        """
+        Build and finalize the module configuration block.
+
+        Returns:
+            The constructed `ModuleConfig` metadata instance.
+        """
         return self._config
 
 
@@ -328,7 +549,32 @@ class Module:
 
 @dataclass
 class AuthConfig:
-    """Authentication configuration."""
+    """
+    Global authentication configuration parameters.
+
+    Defines token storage backend, cryptographic hashing algorithms, TTLs, issuer,
+    audience, and default security guards for the workspace.
+
+    Parameters:
+        enabled: If `True` (default), enables authentication middleware.
+        store_type: Token storage backend. Must be `"memory"`, `"redis"`, `"database"`, or `"custom"`.
+        secret_key: Cryptographic key used to sign and verify JSON Web Tokens (JWT).
+        algorithm: Hashing algorithm for tokens (e.g. `"HS256"`).
+        issuer: Token issuer claim (`iss`). Defaults to `"aquilia"`.
+        audience: Token audience claim (`aud`). Defaults to `"aquilia-app"`.
+        access_token_ttl_minutes: Lifespan of access tokens in minutes. Defaults to `60`.
+        refresh_token_ttl_days: Lifespan of refresh tokens in days. Defaults to `30`.
+        require_auth_by_default: If `True`, all controller routes require authentication unless marked public.
+
+    Examples:
+        ```python
+        config = AuthConfig(
+            secret_key="my-super-secret-key",
+            store_type="redis",
+            require_auth_by_default=True
+        )
+        ```
+    """
 
     enabled: bool = True
     store_type: str = "memory"
@@ -366,7 +612,41 @@ class AuthConfig:
 
 
 class Workspace:
-    """Fluent workspace builder."""
+    """
+    Fluent builder class to configure the application workspace.
+
+    Workspace serves as the centralized root configuration, defining runtime bindings,
+    global databases, security policies, background tasks, telemetry tracking, and
+    registering pointers to application modules.
+
+    Examples:
+        Basic usage:
+        ```python
+        from aquilia.workspace import Workspace, Module
+
+        workspace = (
+            Workspace("my-service", version="1.0.0")
+            .runtime(mode="dev", port=3000)
+            .module(Module("users"))
+        )
+        ```
+
+        Advanced workspace with security, telemetry, and mail integrations:
+        ```python
+        workspace = (
+            Workspace("billing-service")
+            .runtime(mode="prod", port=8080)
+            .telemetry(metrics_enabled=True)
+            .security(cors_enabled=True)
+            .integrate(
+                MailIntegration(
+                    default_from="support@service.com",
+                    providers=[SMTPProvider(host="smtp.service.com")]
+                )
+            )
+        )
+        ```
+    """
 
     def __init__(self, name: str, version: str = "0.1.0", description: str = ""):
         self._name = name

--- a/docs/modules/auth/api-reference.md
+++ b/docs/modules/auth/api-reference.md
@@ -2597,17 +2597,32 @@ Methods:
 
 | Method | Signature | Summary |
 | --- | --- | --- |
-| `save_password` | `async def save_password(self, credential: PasswordCredential)` | Save password credential. |
+| `save_password` | `async def save_password(self, credential: PasswordCredential)` | Save password credential (upsert). |
+| `create_password` | `async def create_password(self, credential: PasswordCredential)` | Create password credential (`CredentialStore` protocol; delegates to `save_password`). |
+| `update_password` | `async def update_password(self, credential: PasswordCredential)` | Update password credential (`CredentialStore` protocol; delegates to `save_password`). |
 | `get_password` | `async def get_password(self, identity_id: str)` | Get password credential. |
 | `delete_password` | `async def delete_password(self, identity_id: str)` | Delete password credential. |
-| `save_api_key` | `async def save_api_key(self, credential: ApiKeyCredential)` | Save API key credential. |
+| `save_api_key` | `async def save_api_key(self, credential: ApiKeyCredential)` | Save API key credential (indexes by both `key_id` and `key_hash`). |
+| `create_api_key` | `async def create_api_key(self, credential: ApiKeyCredential)` | Create API key credential (`CredentialStore` protocol; raises `ConflictFault` if `key_id` exists). |
 | `get_api_key` | `async def get_api_key(self, key_id: str)` | Get API key credential. |
-| `get_api_key_by_prefix` | `async def get_api_key_by_prefix(self, prefix: str)` | Get API key by prefix (first 8 chars). |
+| `get_api_key_by_hash` | `async def get_api_key_by_hash(self, key_hash: str)` | Get API key by its HMAC hash — O(1) lookup (`CredentialStore` protocol). |
+| `get_api_key_by_prefix` | `async def get_api_key_by_prefix(self, prefix: str)` | Get API key by prefix (first 8 chars). Deprecated: prefer `get_api_key_by_hash`. |
 | `list_api_keys` | `async def list_api_keys(self, identity_id: str)` | List all API keys for identity. |
-| `delete_api_key` | `async def delete_api_key(self, key_id: str)` | Delete API key credential. |
+| `revoke_api_key` | `async def revoke_api_key(self, key_id: str)` | Soft-revoke API key — sets `status = CredentialStatus.REVOKED` (`CredentialStore` protocol). |
+| `delete_api_key` | `async def delete_api_key(self, key_id: str)` | Hard-delete API key credential. |
 | `save_mfa` | `async def save_mfa(self, credential: MFACredential)` | Save MFA credential. |
+| `create_mfa` | `async def create_mfa(self, credential: MFACredential)` | Create MFA credential (`CredentialStore` protocol; delegates to `save_mfa`). |
+| `update_mfa` | `async def update_mfa(self, credential: MFACredential)` | Update MFA credential (`CredentialStore` protocol; delegates to `save_mfa`). |
 | `get_mfa` | `async def get_mfa(self, identity_id: str, mfa_type: str \| None=None)` | Get MFA credentials for identity. |
 | `delete_mfa` | `async def delete_mfa(self, identity_id: str, mfa_type: str \| None=None)` | Delete MFA credentials. |
+
+`MemoryCredentialStore` now fully satisfies the `CredentialStore` protocol under the
+protocol's own method names (`create_password`/`update_password`/`create_api_key`/
+`get_api_key_by_hash`/`revoke_api_key`/`create_mfa`/`update_mfa`) — previously only
+the ad hoc `save_*`/`get_api_key_by_prefix` names existed, and `AuthManager` was
+written against those, not the protocol. Custom `CredentialStore` implementations
+should implement the protocol names; the `save_*`/`get_api_key_by_prefix` names
+remain for backward compatibility but are not part of the protocol.
 
 ### `MemoryOAuthClientStore`
 
@@ -2624,6 +2639,7 @@ Methods:
 | `update` | `async def update(self, client: OAuthClient)` | Update OAuth client. |
 | `delete` | `async def delete(self, client_id: str)` | Delete OAuth client. |
 | `list` | `async def list(self, owner_id: str \| None=None, limit: int=100, offset: int=0)` | List OAuth clients, optionally filtered by owner (from metadata). |
+| `list_all` | `async def list_all(self)` | List all OAuth clients (`OAuthClientStore` protocol; delegates to `list()`). |
 
 ### `MemoryTokenStore`
 
@@ -2789,7 +2805,16 @@ Fields and class attributes:
 | `audience` | `list[str]` | `field(default_factory=lambda: ['api'])` |
 | `access_token_ttl` | `int` | `3600` |
 | `refresh_token_ttl` | `int` | `2592000` |
-| `algorithm` | `str` | `KeyAlgorithm.RS256` |
+
+`TokenConfig` does **not** configure the signing algorithm (the previous
+`algorithm: str = KeyAlgorithm.RS256` field was dead — never read by
+`TokenManager`, and misleadingly implied an RS256 default). The algorithm is a
+property of the active `KeyDescriptor` inside the `KeyRing` passed to
+`TokenManager(key_ring=..., token_store=...)`. Build it with
+`KeyDescriptor.generate(kid=..., algorithm=...)`; it defaults to `HS256`
+(stdlib-only, zero extra dependencies) unless an asymmetric algorithm
+(`RS256`/`ES256`/`EdDSA`, which require `pip install cryptography`) is
+explicitly requested.
 
 ### `TokenStore`
 

--- a/tests/test_auth_system.py
+++ b/tests/test_auth_system.py
@@ -251,23 +251,33 @@ class TestBuiltInConditions:
         identity = MagicMock(attributes={}, status="ACTIVE")
         assert is_verified(identity, None, None) is True
 
+    @staticmethod
+    def _identity_with_roles(roles, **extra):
+        """MagicMock identity whose get_attribute() genuinely reads from
+        attributes, matching the real Identity contract (roles/scopes live
+        in `attributes`, not as direct attributes)."""
+        attrs = {"roles": roles}
+        identity = MagicMock(**extra)
+        identity.get_attribute = lambda key, default=None: attrs.get(key, default)
+        return identity
+
     def test_is_owner_or_admin_admin_role(self):
         from aquilia.auth.clearance import is_owner_or_admin
 
-        identity = MagicMock(roles={"admin"})
+        identity = self._identity_with_roles({"admin"})
         assert is_owner_or_admin(identity, None, None) is True
 
     def test_is_owner_or_admin_owner(self):
         from aquilia.auth.clearance import is_owner_or_admin
 
-        identity = MagicMock(id="user-1", roles=set())
+        identity = self._identity_with_roles(set(), id="user-1")
         ctx = MagicMock(state={"resource_owner_id": "user-1"})
         assert is_owner_or_admin(identity, None, ctx) is True
 
     def test_is_owner_or_admin_not_owner(self):
         from aquilia.auth.clearance import is_owner_or_admin
 
-        identity = MagicMock(id="user-1", roles=set())
+        identity = self._identity_with_roles(set(), id="user-1")
         ctx = MagicMock(state={"resource_owner_id": "user-2"})
         assert is_owner_or_admin(identity, None, ctx) is False
 
@@ -345,14 +355,23 @@ class TestClearanceEngine:
         tenant_id: str = None,
         attributes: dict = None,
     ):
+        # attrs backs get_attribute(), matching the real Identity contract
+        # (roles/scopes/permissions live in `attributes`, not as direct
+        # attributes on the identity object).
+        attrs = dict(attributes or {})
+        attrs.setdefault("roles", roles or set())
+        attrs.setdefault("scopes", scopes or set())
+        attrs.setdefault("permissions", set())
+
         identity = MagicMock()
         identity.id = id
         identity.roles = roles or set()
         identity.scopes = scopes or set()
         identity.status = status
         identity.tenant_id = tenant_id
-        identity.attributes = attributes or {}
+        identity.attributes = attrs
         identity.permissions = set()
+        identity.get_attribute = lambda key, default=None: attrs.get(key, default)
         return identity
 
     @pytest.mark.asyncio
@@ -1556,7 +1575,7 @@ class TestFlowGuards:
         fake_identity = object()
 
         auth_manager = AsyncMock()
-        auth_manager.identity_store.get_identity.return_value = fake_identity
+        auth_manager.identity_store.get.return_value = fake_identity
 
         with patch("aquilia.auth.integration.flow_guards.get_identity_id", return_value="identity-1"):
             guard = RequireSessionAuthGuard()

--- a/tests/test_integration_resolution.py
+++ b/tests/test_integration_resolution.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from aquilia import Workspace
+from aquilia.faults.domains import ConfigMissingFault
+from aquilia.integrations import (
+    DatabaseIntegration,
+    MailIntegration,
+)
+from aquilia.integrations import SmtpProvider as SMTPProvider
+from aquilia.pyconfig import AquilaConfig, Env, Secret
+
+
+def test_env_resolution(monkeypatch):
+    """Verify Env resolution in integrations."""
+    monkeypatch.setenv("EMAIL_HOST_USER", "test_user_from_env")
+
+    provider = SMTPProvider(username=Env("EMAIL_HOST_USER"))
+    # The provider wrapper resolves values at instantiation time and to_dict() returns them resolved
+    assert provider.username == "test_user_from_env"
+
+    d = provider.to_dict()
+    assert d["username"] == "test_user_from_env"
+
+
+def test_secret_resolution(monkeypatch):
+    """Verify Secret resolution in integrations."""
+    monkeypatch.setenv("EMAIL_HOST_PASSWORD", "secret_pass_123")
+
+    provider = SMTPProvider(password=Secret("EMAIL_HOST_PASSWORD"))
+    assert provider.password == "secret_pass_123"
+
+    d = provider.to_dict()
+    assert d["password"] == "secret_pass_123"
+
+
+def test_pyconfig_resolution(monkeypatch):
+    """Verify PyConfig value resolution in integrations."""
+    monkeypatch.setenv("EMAIL_USER_VAR", "config_user")
+    monkeypatch.setenv("EMAIL_PASS_VAR", "config_pass")
+
+    class TestEnv(AquilaConfig):
+        env = "test_env"
+
+        class mail(AquilaConfig.Mail):
+            email_user = Env("EMAIL_USER_VAR", cast=str)
+            email_password = Secret(env="EMAIL_PASS_VAR")
+
+    # SMTPProvider with PyConfig fields
+    provider = SMTPProvider(
+        username=TestEnv.mail.email_user,
+        password=TestEnv.mail.email_password,
+    )
+
+    assert provider.username == "config_user"
+    assert provider.password == "config_pass"
+
+    d = provider.to_dict()
+    assert d["username"] == "config_user"
+    assert d["password"] == "config_pass"
+
+
+def test_type_casting(monkeypatch):
+    """Verify that Env type casting works correctly in integrations."""
+    monkeypatch.setenv("EMAIL_PORT_VAR", "465")
+
+    provider = SMTPProvider(port=Env("EMAIL_PORT_VAR", cast=int))
+
+    assert provider.port == 465
+    assert isinstance(provider.port, int)
+
+    d = provider.to_dict()
+    assert d["port"] == 465
+
+
+def test_validation_errors(monkeypatch):
+    """Verify that invalid values fail with meaningful errors."""
+    # Env has required=True and is not set, resolving it should raise ConfigMissingFault
+    if "REQUIRED_NOT_SET" in os.environ:
+        monkeypatch.delenv("REQUIRED_NOT_SET", raising=False)
+
+    with pytest.raises(ConfigMissingFault):
+        SMTPProvider(username=Env("REQUIRED_NOT_SET", required=True))
+
+    with pytest.raises(ConfigMissingFault):
+        SMTPProvider(password=Secret(env="REQUIRED_NOT_SET", required=True))
+
+
+def test_backwards_compatibility():
+    """Verify that existing string-based and int-based configurations function unchanged."""
+    provider = SMTPProvider(
+        host="smtp.example.com",
+        port=587,
+        username="flat_string_user",
+        password="flat_string_password",
+    )
+
+    assert provider.host == "smtp.example.com"
+    assert provider.port == 587
+    assert provider.username == "flat_string_user"
+    assert provider.password == "flat_string_password"
+
+    d = provider.to_dict()
+    assert d["host"] == "smtp.example.com"
+    assert d["port"] == 587
+    assert d["username"] == "flat_string_user"
+    assert d["password"] == "flat_string_password"
+
+
+def test_integration_nested_in_workspace(monkeypatch):
+    """Verify that resolving a full workspace config resolves nested Env/Secret/PyConfig wrappers."""
+    monkeypatch.setenv("MAIL_FROM", "workspace_from@aquilia.io")
+    monkeypatch.setenv("DB_URL", "postgresql://db.aquilia.io/prod")
+
+    mail_integration = MailIntegration(
+        default_from=Env("MAIL_FROM"), providers=[SMTPProvider(username=Env("MAIL_FROM"))]
+    )
+
+    db_integration = DatabaseIntegration(url=Env("DB_URL"))
+
+    workspace = Workspace("test-workspace").integrate(mail_integration).integrate(db_integration)
+
+    config = workspace.to_dict()
+
+    assert config["integrations"]["mail"]["default_from"] == "workspace_from@aquilia.io"
+    assert config["integrations"]["mail"]["providers"][0]["username"] == "workspace_from@aquilia.io"
+    assert config["integrations"]["database"]["url"] == "postgresql://db.aquilia.io/prod"

--- a/tests/test_phase14_faults_subsystems.py
+++ b/tests/test_phase14_faults_subsystems.py
@@ -1005,7 +1005,10 @@ class TestAdminFlowGuards:
         guard = AdminAuthGuard()
         for role in ["superadmin", "admin", "staff", "editor", "viewer"]:
             ctx = MagicMock()
-            ctx.identity = MagicMock()
+            # spec=["roles"] keeps this a plain-attribute identity (no
+            # auto-vivified get_attribute), matching AdminAuthGuard's
+            # get_attribute-first-then-.roles fallback chain.
+            ctx.identity = MagicMock(spec=["roles"])
             ctx.identity.roles = [role]
             assert guard(ctx) is True, f"Role '{role}' should be accepted"
 
@@ -1013,7 +1016,7 @@ class TestAdminFlowGuards:
         """AuthGuard rejects non-admin roles."""
         guard = AdminAuthGuard()
         ctx = MagicMock()
-        ctx.identity = MagicMock()
+        ctx.identity = MagicMock(spec=["roles"])
         ctx.identity.roles = ["user", "guest"]
         assert guard(ctx) is False
 


### PR DESCRIPTION
Full forensic audit of `aquilia/auth/` and `aquilia/sessions/` against their own declared protocols. Found and fixed protocol/implementation drift, broken guard call chains, a credential-leaking serialization path, and several session lifecycle correctness bugs.

**Highlights (see `CHANGELOG.md` → `[1.3.0b1]` → "Fixed — Authentication & Session Forensic Audit" for the full file-by-file list):**

- `CredentialStore` protocol vs `MemoryCredentialStore`: the store implemented none of the protocol's declared write methods under their real names (`save_password` instead of `create_password`/`update_password`, `get_api_key_by_prefix` instead of `get_api_key_by_hash`, no `revoke_api_key`/`create_mfa`/`update_mfa`). Any custom `CredentialStore` written against the published protocol would crash `AuthManager` on first use. API key lookup also switched from an O(n) prefix scan to an O(1) hash index.
- `RequireSessionAuthGuard` called a nonexistent `identity_store.get_identity()` — `AttributeError` on every session-authenticated request.
- `RequirePolicyGuard` / `RequirePermissionGuard` called `AuthzEngine` with swapped arguments, missing/incorrect `await`, and wrong return-type assumptions — every policy- or permission-guarded route was unconditionally denied.
- `identity.roles`/`.scopes`/`.permissions` read as direct attributes in `clearance.py`, `flow_guards.py`, `admin/subsystems.py`, and the template `can()`/`is_owner()` helpers — always empty or wrong against the real `Identity` model (roles/scopes live in `attributes`, reachable only via `get_attribute()`). `can()` was also a hardcoded `return True` placeholder — an outright authorization bypass.
- `Clearance.merge()` silently downgraded class-level access requirements to `AUTHENTICATED` whenever a method-level `@grant()` didn't restate the level.
- `KeyDescriptor.to_dict()` leaked the live HMAC signing secret via the `public_key` field even in "safe" mode.
- `OAuth2Manager.validate_client()` only verified a client secret if the caller happened to supply one — confidential-client impersonation.
- `TokenConfig.algorithm` was dead config defaulting to `RS256`, contradicting the documented HS256 zero-dependency default; `KeyRingProvider` hard-coded `RS256`, crashing DI-based zero-config startup without `cryptography` installed.
- Refresh token rotation dropped `roles`/`tenant_id` claims on every refresh.
- Session engine: rotation deleted the old session before the concurrency check that could reject the commit (could leave a caller with no valid session at all); new anonymous sessions were never persisted (flag mutation didn't mark the session dirty); corrupted session files crashed instead of degrading gracefully like every other invalid-session case; `MemoryStore.exists()`/`FileStore.delete()` skipped the lock every sibling method holds.

## Docs

- `docs/modules/auth/api-reference.md`: regenerated the stale `CredentialStore`/`MemoryCredentialStore`/`TokenConfig` entries to match the fixed protocol surface.
- `aqdocx/src/pages/docs/auth/{Overview,Tokens}.tsx`, `aqdocx/src/pages/docs/authz/Policies.tsx`: corrected example code that demonstrated the now-fixed buggy patterns (`save_password` instead of `create_password`, `RS256` implied as default, `identity.roles` direct access).
- `CHANGELOG.md`: structured entry under `[1.3.0b1]`.

## Test plan

- [x] Full existing suite: `pytest tests/` → 6687 passed, 0 failed, 1 skipped
- [x] `ruff check` clean on all modified files
- [x] Manual end-to-end sanity: password auth → refresh token round trip preserves `roles`; `CredentialStore` protocol methods (`create_password`/`update_password`/`get_api_key_by_hash`/`revoke_api_key`) exercised directly; `KeyDescriptor.to_dict(include_private_key=False)` confirmed to no longer leak HMAC secrets for symmetric algorithms
- [x] Updated pre-existing tests whose fixtures encoded the fixed bugs (`MagicMock` identities relying on direct `.roles`/`.scopes` attributes instead of `get_attribute()`)
