### PR TITLE
Fix #67: Rate-limit rejection returns 429 instead of raising NameError

### DIFF
--- a/aquilia/middleware_ext/rate_limit.py
+++ b/aquilia/middleware_ext/rate_limit.py
@@ -31,10 +31,14 @@ from typing import (
 from aquilia.faults.domains import RateLimitExceededFault
 from aquilia.middleware import Middleware
 
+# Runtime import, not TYPE_CHECKING: _rate_limited_response constructs a Response
+# when a limit trips. aquilia.response does not import middleware_ext, so this
+# introduces no cycle.
+from aquilia.response import Response
+
 if TYPE_CHECKING:
     from aquilia.controller.base import RequestCtx
     from aquilia.request import Request
-    from aquilia.response import Response
 
 Handler = Callable[["Request", "RequestCtx"], Awaitable["Response"]]
 

--- a/tests/test_rate_limit_rejection.py
+++ b/tests/test_rate_limit_rejection.py
@@ -1,0 +1,87 @@
+"""Regression tests for issue #67 -- rate-limit rejection must return 429.
+
+`Response` was imported under TYPE_CHECKING only, so `_rate_limited_response`
+raised NameError at runtime and no request was ever actually rejected. These
+tests exercise the rejection path directly, for both response formats.
+"""
+
+from aquilia.middleware_ext.rate_limit import RateLimitMiddleware, RateLimitRule
+from aquilia.response import Response
+
+
+class _FakeRequest:
+    def __init__(self, ip: str = "1.2.3.4"):
+        self.state: dict = {}
+        self.method = "GET"
+        self.path = "/limited"
+        # ip_key_extractor reads the ASGI scope, not a .client attribute.
+        self._scope = {"client": (ip, 0)}
+
+    def header(self, name: str):
+        return None
+
+
+async def _next_handler(request, ctx):
+    return Response.json({"ok": True})
+
+
+async def test_json_rejection_returns_429():
+    mw = RateLimitMiddleware(rules=[RateLimitRule(limit=1, window=60)])
+    request = _FakeRequest()
+
+    assert (await mw(request, None, _next_handler)).status == 200
+
+    # Previously raised NameError instead of building the 429.
+    rejected = await mw(request, None, _next_handler)
+    assert rejected.status == 429
+
+
+async def test_plain_rejection_returns_429():
+    mw = RateLimitMiddleware(
+        rules=[RateLimitRule(limit=1, window=60)],
+        response_format="plain",
+    )
+    request = _FakeRequest()
+
+    assert (await mw(request, None, _next_handler)).status == 200
+    assert (await mw(request, None, _next_handler)).status == 429
+
+
+async def test_rejection_carries_retry_and_limit_headers():
+    mw = RateLimitMiddleware(rules=[RateLimitRule(limit=1, window=60)])
+    request = _FakeRequest()
+
+    await mw(request, None, _next_handler)
+    rejected = await mw(request, None, _next_handler)
+
+    assert rejected.headers["retry-after"]
+    assert rejected.headers["x-ratelimit-limit"] == "1"
+    assert rejected.headers["x-ratelimit-remaining"] == "0"
+
+
+async def test_rejection_attaches_fault_for_observability():
+    """resp._fault was unreachable while the path raised NameError."""
+    mw = RateLimitMiddleware(rules=[RateLimitRule(limit=1, window=60)])
+    request = _FakeRequest()
+
+    await mw(request, None, _next_handler)
+    rejected = await mw(request, None, _next_handler)
+
+    assert rejected._fault is not None
+    assert rejected._fault.code == rejected.headers["x-fault-code"]
+
+
+async def test_under_limit_requests_are_untouched():
+    mw = RateLimitMiddleware(rules=[RateLimitRule(limit=5, window=60)])
+    request = _FakeRequest()
+
+    for _ in range(5):
+        assert (await mw(request, None, _next_handler)).status == 200
+
+
+async def test_distinct_ips_are_limited_independently():
+    mw = RateLimitMiddleware(rules=[RateLimitRule(limit=1, window=60)])
+
+    assert (await mw(_FakeRequest("10.0.0.1"), None, _next_handler)).status == 200
+    assert (await mw(_FakeRequest("10.0.0.1"), None, _next_handler)).status == 429
+    assert (await mw(_FakeRequest("10.0.0.2"), None, _next_handler)).status == 200


### PR DESCRIPTION
Fixes #67

## Problem

`RateLimitMiddleware` never rejected a request. `Response` was imported under `TYPE_CHECKING` only, but `_rate_limited_response` constructs one at runtime, so the first request to trip a limit raised `NameError: name 'Response' is not defined` — surfacing as an unhandled 500 rather than a 429.

This affected **all** keying modes, including the default IP-based rule, so rate-limit enforcement was non-functional. Only the rejection path was broken; under-limit requests returned normally, which is why it went unnoticed.

## Change

One-line move of `from aquilia.response import Response` out of the `TYPE_CHECKING` block, with a comment recording why it must stay at runtime. `aquilia.response` does not import `aquilia.middleware_ext`, so this adds no cycle — verified by the import-order tests from #63.

## Verification

`tests/test_rate_limit_rejection.py` — 6 tests covering both response formats, the `retry-after` / `x-ratelimit-*` headers, the previously-unreachable `resp._fault` observability hook, and per-IP bucket isolation.

Confirmed the tests actually catch the bug: **5 of 6 fail without the fix**, all 6 pass with it.

Full suite: `8836 passed, 8 skipped, 1 failed`. The single failure is `test_orm_enterprise_fields.py::test_encrypted_field_round_trips_with_configured_key`, which **fails identically on unmodified `master`** (a Fernet key issue in the local environment) — unrelated to this change.

`ruff check aquilia/` and `ruff format --check` clean.

## Note on the diff

While writing the test I found `ip_key_extractor` reads `request._scope["client"]` rather than a `.client` attribute; the test fake was corrected to match. No production code was changed for that.

## Review order

Stacked on #66 (`fix/63-circular-import`) because the test module imports `aquilia.middleware_ext.rate_limit` directly and would otherwise hit the circular import that #63 fixes. Merge #66 first; this PR then retargets to `master` cleanly.

Found while writing the regression test for #64 — that PR's end-to-end enforcement assertion needs a real 429, so it stacks on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)