### PR TITLE
Fix #64: Register identity-based rate-limit rules after auth

### DIFF
--- a/aquilia/middleware_ext/rate_limit.py
+++ b/aquilia/middleware_ext/rate_limit.py
@@ -20,6 +20,7 @@ All middleware follow the Aquilia async signature:
 
 from __future__ import annotations
 
+import logging
 import math
 import time
 from collections.abc import Awaitable, Callable
@@ -41,6 +42,8 @@ if TYPE_CHECKING:
     from aquilia.request import Request
 
 Handler = Callable[["Request", "RequestCtx"], Awaitable["Response"]]
+
+logger = logging.getLogger("aquilia.middleware.rate_limit")
 
 
 # ─── Key extractors ──────────────────────────────────────────────────────────
@@ -276,9 +279,14 @@ class RateLimitRule:
         burst: Extra burst capacity (token_bucket only). Defaults to limit.
         scope: Which paths this rule applies to ("*" = all).
         methods: HTTP methods this rule applies to (empty = all).
+        requires_identity: Whether ``key_func`` needs an authenticated identity
+                  on ``request.state``. Auto-detected for ``user_key_extractor``;
+                  set explicitly for custom identity-based extractors. Rules with
+                  this set must be registered *after* the auth middleware, or
+                  they can never produce a key.
     """
 
-    __slots__ = ("limit", "window", "algorithm", "key_func", "burst", "scope", "methods")
+    __slots__ = ("limit", "window", "algorithm", "key_func", "burst", "scope", "methods", "requires_identity")
 
     def __init__(
         self,
@@ -289,6 +297,7 @@ class RateLimitRule:
         burst: int | None = None,
         scope: str = "*",
         methods: list[str] | None = None,
+        requires_identity: bool | None = None,
     ):
         self.limit = limit
         self.window = window
@@ -297,6 +306,11 @@ class RateLimitRule:
         self.burst = burst
         self.scope = scope
         self.methods = methods or []
+        # Auto-detect for the built-in extractor so the common config path
+        # ("per_user": true) gets correct ordering without extra wiring.
+        if requires_identity is None:
+            requires_identity = self.key_func is user_key_extractor
+        self.requires_identity = requires_identity
 
     def matches(self, request: Request) -> bool:
         """Check if this rule applies to the given request."""
@@ -353,6 +367,7 @@ class RateLimitMiddleware(Middleware):
         self._include_headers = include_headers
         self._exempt_paths: set = set(exempt_paths or ["/health", "/healthz", "/ready"])
         self._store = _BucketStore()
+        self._warned_missing_identity = False
 
     async def __call__(
         self,
@@ -375,6 +390,16 @@ class RateLimitMiddleware(Middleware):
 
             key = rule.key_func(request)
             if key is None:
+                if rule.requires_identity and not self._warned_missing_identity:
+                    # Ordering bug, not a normal miss: an identity rule that never
+                    # sees an identity silently disables itself on every request.
+                    self._warned_missing_identity = True
+                    logger.warning(
+                        "Rate-limit rule requires an authenticated identity but none was found on "
+                        "request.state. The rate-limit middleware is most likely registered before "
+                        "the auth middleware, which disables this rule entirely. Register it at a "
+                        "priority greater than the auth middleware's (default 15)."
+                    )
                 continue  # Rule doesn't apply (e.g. no user ID)
 
             # Scope the key to the rule

--- a/aquilia/server.py
+++ b/aquilia/server.py
@@ -98,6 +98,12 @@ from aquilia.templates.middleware import TemplateMiddleware
 from aquilia.typing.manifest import ManifestCollection
 from aquilia.versioning.core import VERSION_NEUTRAL
 
+# Middleware priorities are ascending = outer = executed first. Auth resolves the
+# identity that identity-based rate-limit rules key on, so those rules must be
+# registered strictly after it. Keep these two in lockstep.
+_AUTH_PRIORITY = 15
+_RATE_LIMIT_IDENTITY_PRIORITY = _AUTH_PRIORITY + 1
+
 
 class ServerRequestScopeMiddleware(Middleware):
     """Request scope middleware -- stores container refs and cleans up."""
@@ -415,7 +421,7 @@ class AquiliaServer:
                             fault_engine=self.fault_engine,
                         ),
                         scope="global",
-                        priority=15,  # Replaces session middleware
+                        priority=_AUTH_PRIORITY,  # Replaces session middleware
                         name="auth",
                     )
 
@@ -485,7 +491,7 @@ class AquiliaServer:
                 self.middleware_stack.add(
                     SessionMiddleware(self._session_engine),
                     scope="global",
-                    priority=15,
+                    priority=_AUTH_PRIORITY,
                     name="session",
                 )
 
@@ -1048,7 +1054,7 @@ class AquiliaServer:
             # Wire CSRF token function into TemplateMiddleware if present
             self._csrf_token_func = _csrf_token_func
 
-        # ── Rate Limiting (priority 12) ──────────────────────────────────
+        # ── Rate Limiting (priority 12 for IP rules, 16 for identity rules) ──
         rl_config = security_config.get("rate_limit") or integrations.get("rate_limit", {})
         if security_config.get("rate_limiting") or (rl_config and rl_config.get("enabled")):
             rules = []
@@ -1067,11 +1073,26 @@ class AquiliaServer:
             else:
                 rules.append(RateLimitRule(limit=100, window=60))
                 exempt = None
-            mw = RateLimitMiddleware(
-                rules=rules,
-                exempt_paths=exempt,
-            )
-            self.middleware_stack.add(mw, scope="global", priority=12, name="rate_limit")
+
+            # Identity-based rules must run *after* the auth middleware (priority
+            # 15) or their key extractor sees no identity and the rule silently
+            # never applies. IP-based rules stay early, so anonymous abuse is
+            # rejected before paying for auth resolution.
+            identity_rules = [r for r in rules if r.requires_identity]
+            anon_rules = [r for r in rules if not r.requires_identity]
+
+            for group, priority, name in (
+                (anon_rules, 12, "rate_limit"),
+                (identity_rules, _RATE_LIMIT_IDENTITY_PRIORITY, "rate_limit_identity"),
+            ):
+                if not group:
+                    continue
+                self.middleware_stack.add(
+                    RateLimitMiddleware(rules=group, exempt_paths=exempt),
+                    scope="global",
+                    priority=priority,
+                    name=name,
+                )
 
     def _is_debug(self) -> bool:
         """Check if debug mode is enabled.

--- a/tests/test_rate_limit_ordering.py
+++ b/tests/test_rate_limit_ordering.py
@@ -1,0 +1,119 @@
+"""Regression tests for per-user rate-limit ordering (#64).
+
+``user_key_extractor`` reads the identity that the auth middleware puts on
+``request.state``. Rate limiting used to register at priority 12 and auth at 15
+— and since ascending priority means outer/earlier, the extractor always ran
+first, always returned None, and every per-user rule was silently skipped.
+"""
+
+import logging
+
+from aquilia.middleware_ext.rate_limit import (
+    RateLimitMiddleware,
+    RateLimitRule,
+    ip_key_extractor,
+    user_key_extractor,
+)
+from aquilia.response import Response
+from aquilia.server import _AUTH_PRIORITY, _RATE_LIMIT_IDENTITY_PRIORITY
+
+
+class _FakeIdentity:
+    def __init__(self, ident: str):
+        self.id = ident
+
+
+class _FakeRequest:
+    """Minimal stand-in — the extractors only touch .state."""
+
+    def __init__(self, state: dict | None = None):
+        self.state = state or {}
+        self.method = "GET"
+        self.path = "/api/thing"
+
+
+def test_identity_rules_register_after_auth():
+    """The whole bug: an identity rule evaluated before auth can never key."""
+    assert _RATE_LIMIT_IDENTITY_PRIORITY > _AUTH_PRIORITY
+
+
+def test_per_user_rule_is_flagged_as_identity_dependent():
+    """Auto-detection drives the priority split, so it must hold for the config path."""
+    rule = RateLimitRule(key_func=user_key_extractor)
+    assert rule.requires_identity is True
+
+
+def test_ip_rule_is_not_identity_dependent():
+    rule = RateLimitRule(key_func=ip_key_extractor)
+    assert rule.requires_identity is False
+
+    # Default (no key_func) is IP-based and must stay early in the chain.
+    assert RateLimitRule().requires_identity is False
+
+
+def test_custom_extractor_can_declare_identity_dependence():
+    rule = RateLimitRule(key_func=lambda r: "custom", requires_identity=True)
+    assert rule.requires_identity is True
+
+
+def test_user_key_extractor_needs_identity_on_state():
+    """Before auth runs, state is empty and the rule yields no key."""
+    assert user_key_extractor(_FakeRequest()) is None
+
+    after_auth = _FakeRequest({"identity": _FakeIdentity("u-42")})
+    assert user_key_extractor(after_auth) == "user:u-42"
+
+
+async def test_missing_identity_warns_instead_of_silently_skipping(caplog):
+    """A misregistered identity rule must be loud — that was the real defect."""
+    mw = RateLimitMiddleware(rules=[RateLimitRule(key_func=user_key_extractor)])
+    request = _FakeRequest()
+    sentinel = object()
+
+    async def next_handler(req, ctx):
+        return sentinel
+
+    with caplog.at_level(logging.WARNING, logger="aquilia.middleware.rate_limit"):
+        result = await mw(request, None, next_handler)
+
+    # Request still passes through — the rule is skipped, not enforced.
+    assert result is sentinel
+    assert "requires an authenticated identity" in caplog.text
+    assert mw._warned_missing_identity is True
+
+    # Warn once, not once per request.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="aquilia.middleware.rate_limit"):
+        await mw(request, None, next_handler)
+    assert "requires an authenticated identity" not in caplog.text
+
+
+async def test_identity_rule_enforces_once_auth_has_run():
+    """With identity present (post-auth ordering), the limit actually applies."""
+    mw = RateLimitMiddleware(rules=[RateLimitRule(limit=1, window=60, key_func=user_key_extractor)])
+    request = _FakeRequest({"identity": _FakeIdentity("u-42")})
+
+    async def next_handler(req, ctx):
+        return Response.json({"ok": True})
+
+    first = await mw(request, None, next_handler)
+    assert first.status == 200
+
+    # Second call for the same identity exceeds limit=1.
+    second = await mw(request, None, next_handler)
+    assert second.status == 429
+
+
+async def test_identity_rule_keys_per_user_not_globally():
+    """Exhausting user A must not rate-limit user B."""
+    mw = RateLimitMiddleware(rules=[RateLimitRule(limit=1, window=60, key_func=user_key_extractor)])
+
+    async def next_handler(req, ctx):
+        return Response.json({"ok": True})
+
+    user_a = _FakeRequest({"identity": _FakeIdentity("u-a")})
+    assert (await mw(user_a, None, next_handler)).status == 200
+    assert (await mw(user_a, None, next_handler)).status == 429
+
+    user_b = _FakeRequest({"identity": _FakeIdentity("u-b")})
+    assert (await mw(user_b, None, next_handler)).status == 200


### PR DESCRIPTION
Fixes #64

## Problem

Per-user rate limiting was a silent no-op.

`RateLimitMiddleware` registered at priority 12, `AquilAuthMiddleware` at 15. Ascending priority means outer/earlier, so the rate limiter always ran **before** auth. `user_key_extractor` reads `request.state["identity"]` — not yet set — returned `None`, and the rule was skipped by `continue`. No log line, no exception, no metric.

Any deployment setting `security.rate_limit.per_user = true` got **zero enforcement** on that rule. IP-based limiting was unaffected, so limits still appeared to work when tested as a single anonymous client — which is what made this easy to miss.

## Change

- `RateLimitRule` gains `requires_identity`, auto-detected for `user_key_extractor` and overridable for custom extractors that read identity.
- Identity-dependent rules register at `_RATE_LIMIT_IDENTITY_PRIORITY` (16), after `_AUTH_PRIORITY` (15). IP-only rules stay at 12, so anonymous abuse is still rejected cheaply before paying the auth cost — this keeps the ordering rationale the original priority was chosen for.
- Auth and session middleware now derive their priority from `_AUTH_PRIORITY` rather than a repeated literal `15`, so the two values cannot drift apart and silently reintroduce this bug.
- A rule that requires identity but finds none now emits a one-time warning instead of skipping silently. The priority fix prevents this in the default wiring; the warning covers manual/custom registration that ordering alone cannot.

I took the audit's option (a) over the simpler "move everything to 16" — that variant would make unauthenticated flood traffic pay the auth lookup before rejection, which is the cost the current placement exists to avoid.

## Verification

`tests/test_rate_limit_ordering.py` — 8 tests: priority-ordering invariants, `requires_identity` auto-detection and override, the warning on identity-less evaluation, and an end-to-end check that a second request from the same authenticated user actually receives **429**.

Full suite: `8844 passed, 8 skipped, 1 failed`. The single failure is `test_orm_enterprise_fields.py::test_encrypted_field_round_trips_with_configured_key`, which **fails identically on unmodified `master`** (local Fernet key issue) — unrelated. `ruff check aquilia/` clean.

## Scope note

The audit flagged that auth never sets `request.state["user_id"]`, making that branch of `user_key_extractor` dead. I confirmed `Identity.id` exists and the extractor's `identity` fallback already covers it, and that nothing else in the codebase reads `user_id` — so I reverted the write I had drafted. The ordering bug was the whole root cause; adding a second key would have been unused code.

## Review order

Stacked on #68 → #66. The enforcement test asserts a real 429, which requires the `Response` import fix in #68 (without it the rejection path raises `NameError`). Merge #66, then #68, then this; it retargets to `master` cleanly after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)