### PR TITLE
fix(testing): make pytest an optional dependency (+ ruff format)

### DIFF
--- a/aquilia/inspector/replay.py
+++ b/aquilia/inspector/replay.py
@@ -3,7 +3,7 @@ from typing import Any
 from aquilia.inspector.config import InspectorConfig
 from aquilia.inspector.faults import InspectorReplayFault
 from aquilia.inspector.trace import RequestTrace
-from aquilia.testing import TestClient
+from aquilia.testing.client import TestClient
 
 
 async def run_replay(trace: RequestTrace, config: InspectorConfig, app: Any, headers: dict[str, str]) -> Any:

--- a/aquilia/testing/fixtures.py
+++ b/aquilia/testing/fixtures.py
@@ -13,9 +13,24 @@ Usage in conftest.py::
 Or use the plugin entry point (automatic via pip install).
 """
 
-from __future__ import annotations
+try:
+    import pytest
 
-import pytest
+    HAS_PYTEST = True
+except ImportError:
+    HAS_PYTEST = False
+
+    class _DummyPytest:
+        @staticmethod
+        def fixture(*args, **kwargs):
+            def decorator(func):
+                return func
+
+            if len(args) == 1 and callable(args[0]):
+                return args[0]
+            return decorator
+
+    pytest = _DummyPytest()
 
 from aquilia.config import ConfigLoader
 from aquilia.testing.auth import TestIdentityFactory
@@ -45,6 +60,11 @@ def aquilia_fixtures():
     imported.  The function exists as a documentation anchor and to
     ensure the module's side-effects run.
     """
+    if not HAS_PYTEST:
+        raise ImportError(
+            "pytest is required to use aquilia pytest fixtures. "
+            "Install it with: pip install pytest (or pip install aquilia[test])"
+        )
     pass  # Side-effect of import registers the fixtures below
 
 


### PR DESCRIPTION
## What

Makes `pytest` an optional dependency for CLI and testing imports, so `aquilia.testing.fixtures` and `aquilia.inspector.replay` import cleanly in environments without pytest installed.

The code change is `e78fcfad`, authored previously but never pushed — it existed only in a local `master`. This PR pushes it as its own reviewable change, plus a two-blank-line `ruff format` fix it needed to pass the lint gate (E302-style blank lines after `import pytest` and after a nested `def decorator`).

## Why it's separate

It surfaced while merging the middleware audit stack (#66/#68/#69/#70). Those branches were cut from the local `master` and inadvertently carried this commit, and its formatting break was failing the CI **Lint** job — which gates the test matrix, so no PR in that stack could go green.

Splitting it out keeps each PR to one logical change and unblocks the whole stack.

## Verification

Exactly the two commands CI runs:

```
ruff check aquilia/ --output-format=github   → All checks passed!
ruff format --check aquilia/                 → 648 files already formatted
```

## Merge order

Merge this **first**. #66 → #68 → #69 → #70 rebase on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)